### PR TITLE
Add Pygame starter project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# g
-g
+# Starter Game
+
+This repository contains a minimal desktop game starter built with **Python 3** and **Pygame**. The project opens a window and keeps a basic render loop running at a fixed frame rate, providing a foundation to build upon.
+
+## Technology choice
+
+- **Stack:** Python 3 with the Pygame framework. Pygame offers a straightforward API for creating 2D games and prototypes while remaining easy to install and run cross-platform.
+
+## Prerequisites
+
+- Python 3.9 or newer
+- `pip` for dependency installation
+
+## Setup
+
+1. (Optional) Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use: .venv\\Scripts\\activate
+   ```
+2. Upgrade `pip` and install dependencies declared in `pyproject.toml`:
+   ```bash
+   pip install --upgrade pip
+   pip install -e .
+   ```
+
+## Running the game
+
+Launch the starter window with:
+
+```bash
+python src/main.py
+```
+
+Close the window or press the close button to exit the loop.
+
+## Project structure
+
+```
+.
+├── pyproject.toml   # Project metadata and dependency declaration
+├── README.md        # Project documentation
+└── src/
+    └── main.py      # Entry point that opens the Pygame window
+```
+
+## Next steps
+
+- Add sprites, input handling, and game logic to the main loop.
+- Structure the code into packages/modules as the project grows.
+- Extend the build configuration for packaging or distribution as needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "starter-game"
+version = "0.1.0"
+description = "Basic Pygame window loop starter."
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "pygame>=2.5.2",
+]
+
+[project.optional-dependencies]
+dev = []
+
+[tool.setuptools]
+py-modules = []
+
+[tool.setuptools.package-dir]
+"" = "src"

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,43 @@
+"""Entry point for the basic Pygame window loop."""
+
+import sys
+import pygame
+
+WINDOW_SIZE = (800, 600)
+WINDOW_TITLE = "Starter Game Window"
+BACKGROUND_COLOR = pygame.Color("#1e1e1e")
+FRAME_RATE = 60
+
+def init_pygame() -> pygame.Surface:
+    """Initialize Pygame and create the main window surface."""
+    pygame.init()
+    screen = pygame.display.set_mode(WINDOW_SIZE)
+    pygame.display.set_caption(WINDOW_TITLE)
+    return screen
+
+def handle_events() -> bool:
+    """Process events. Return False when the window should close."""
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            return False
+    return True
+
+def main() -> None:
+    """Run the main loop for the starter game window."""
+    screen = init_pygame()
+    clock = pygame.time.Clock()
+
+    running = True
+    while running:
+        running = handle_events()
+
+        screen.fill(BACKGROUND_COLOR)
+
+        pygame.display.flip()
+        clock.tick(FRAME_RATE)
+
+    pygame.quit()
+    sys.exit()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document the selection of Python 3 with Pygame and add setup/run instructions in the README
- add a basic Pygame entry point that opens a window and runs the main loop
- configure dependencies with a `pyproject.toml` for installing pygame

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ceb8dc0eb08333b28a7a0af7bd68ce