### PR TITLE
Add simple multiplayer cube game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Multiplayer Cubes
+
+A lightweight demonstration of a browser-based multiplayer game where each player controls a colorful cube moving around a shared arena. Built with Express and Socket.IO.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   npm start
+   ```
+3. Open your browser at [http://localhost:3000](http://localhost:3000). Open multiple tabs or devices to see other players join in real time.
+
+## Controls
+
+Use the arrow keys or WASD to move your cube around the playfield. Your cube is outlined in white so you can easily spot it.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "simple-multiplayer-cubes",
+  "version": "1.0.0",
+  "description": "A simple web-based multiplayer cube movement game",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.5"
+  }
+}

--- a/public/client.js
+++ b/public/client.js
@@ -1,0 +1,121 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+const socket = io();
+
+const state = {
+  selfId: null,
+  world: { width: 800, height: 600 },
+  players: new Map(),
+  pressed: new Set(),
+  lastFrame: performance.now(),
+};
+
+function resizeCanvas() {
+  canvas.width = state.world.width;
+  canvas.height = state.world.height;
+}
+
+function drawGround() {
+  const gridSize = 40;
+  ctx.fillStyle = '#6bd4a8';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+  ctx.lineWidth = 1;
+  for (let x = gridSize; x < canvas.width; x += gridSize) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, canvas.height);
+    ctx.stroke();
+  }
+  for (let y = gridSize; y < canvas.height; y += gridSize) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(canvas.width, y);
+    ctx.stroke();
+  }
+}
+
+function drawPlayers() {
+  state.players.forEach((player) => {
+    const size = 40;
+    ctx.fillStyle = player.color;
+    ctx.fillRect(player.x - size / 2, player.y - size / 2, size, size);
+
+    if (player.id === state.selfId) {
+      ctx.strokeStyle = '#ffffff';
+      ctx.lineWidth = 3;
+      ctx.strokeRect(player.x - size / 2 - 2, player.y - size / 2 - 2, size + 4, size + 4);
+    }
+
+    ctx.fillStyle = 'rgba(0,0,0,0.7)';
+    ctx.font = '16px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(player.id.slice(0, 5), player.x, player.y - size / 2 - 8);
+  });
+}
+
+function render() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawGround();
+  drawPlayers();
+}
+
+function directionFromInput() {
+  let x = 0;
+  let y = 0;
+  if (state.pressed.has('ArrowLeft') || state.pressed.has('KeyA')) x -= 1;
+  if (state.pressed.has('ArrowRight') || state.pressed.has('KeyD')) x += 1;
+  if (state.pressed.has('ArrowUp') || state.pressed.has('KeyW')) y -= 1;
+  if (state.pressed.has('ArrowDown') || state.pressed.has('KeyS')) y += 1;
+
+  if (x === 0 && y === 0) {
+    return null;
+  }
+
+  const length = Math.hypot(x, y);
+  return { x: x / length, y: y / length };
+}
+
+function gameLoop(timestamp) {
+  const delta = (timestamp - state.lastFrame) / 1000;
+  state.lastFrame = timestamp;
+
+  const direction = directionFromInput();
+  if (direction) {
+    socket.emit('move', { direction, delta });
+  }
+
+  render();
+  window.requestAnimationFrame(gameLoop);
+}
+
+window.addEventListener('keydown', (event) => {
+  state.pressed.add(event.code);
+});
+
+window.addEventListener('keyup', (event) => {
+  state.pressed.delete(event.code);
+});
+
+socket.on('init', ({ selfId, world, players }) => {
+  state.selfId = selfId;
+  state.world = world;
+  state.players = new Map(players.map((p) => [p.id, p]));
+  resizeCanvas();
+  render();
+});
+
+socket.on('playerJoined', (player) => {
+  state.players.set(player.id, player);
+});
+
+socket.on('playerMoved', (player) => {
+  state.players.set(player.id, player);
+});
+
+socket.on('playerLeft', (playerId) => {
+  state.players.delete(playerId);
+});
+
+window.requestAnimationFrame(gameLoop);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Multiplayer Cubes</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="hud">
+      <h1>Multiplayer Cubes</h1>
+      <p>Use WASD or arrow keys to move your cube around the arena.</p>
+      <p>Open this page in another tab to see another player join in real time.</p>
+    </div>
+    <canvas id="game"></canvas>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script src="client.js"></script>
+  </body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,27 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, sans-serif;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: radial-gradient(circle at top, #fdfcdc, #fee1c7);
+  min-height: 100vh;
+}
+
+.hud {
+  text-align: center;
+  margin: 1rem 0;
+  color: #2b2d42;
+}
+
+canvas {
+  border: 4px solid rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #9be7ff 0%, #b8f2e6 35%, #fff 100%);
+  max-width: calc(100vw - 2rem);
+  max-height: calc(100vh - 12rem);
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+const PORT = process.env.PORT || 3000;
+const WORLD_WIDTH = 800;
+const WORLD_HEIGHT = 600;
+const PLAYER_SPEED = 200; // units per second
+
+app.use(express.static('public'));
+
+const players = new Map();
+
+function randomColor() {
+  const colors = ['#ff595e', '#ffca3a', '#8ac926', '#1982c4', '#6a4c93'];
+  return colors[Math.floor(Math.random() * colors.length)];
+}
+
+io.on('connection', (socket) => {
+  const spawn = {
+    id: socket.id,
+    x: Math.random() * (WORLD_WIDTH - 50) + 25,
+    y: Math.random() * (WORLD_HEIGHT - 50) + 25,
+    color: randomColor(),
+  };
+  players.set(socket.id, spawn);
+
+  socket.emit('init', {
+    selfId: socket.id,
+    world: { width: WORLD_WIDTH, height: WORLD_HEIGHT },
+    players: Array.from(players.values()),
+  });
+
+  socket.broadcast.emit('playerJoined', spawn);
+
+  socket.on('move', ({ direction, delta }) => {
+    const player = players.get(socket.id);
+    if (!player || !direction || typeof delta !== 'number') {
+      return;
+    }
+
+    const clampedDelta = Math.max(0, Math.min(delta, 0.1));
+    const distance = PLAYER_SPEED * clampedDelta;
+    const nextX = player.x + direction.x * distance;
+    const nextY = player.y + direction.y * distance;
+
+    player.x = Math.max(20, Math.min(WORLD_WIDTH - 20, nextX));
+    player.y = Math.max(20, Math.min(WORLD_HEIGHT - 20, nextY));
+
+    players.set(socket.id, player);
+    io.emit('playerMoved', player);
+  });
+
+  socket.on('disconnect', () => {
+    players.delete(socket.id);
+    io.emit('playerLeft', socket.id);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express + Socket.IO server that tracks player state and movement
- create a browser client that renders each player's cube and relays movement input
- document setup and controls for running the demo locally

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3568b3b883338078a4e0c94db95c