### PR TITLE
Enable remote hosting support for multiplayer game

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ A lightweight demonstration of a browser-based multiplayer game where each playe
 ## Controls
 
 Use the arrow keys or WASD to move your cube around the playfield. Your cube is outlined in white so you can easily spot it.
+
+## Deploying the game online
+
+The client can be hosted on a static hosting provider (for example GitHub Pages) while the real-time server runs on any Node-friendly platform such as Render, Railway, Fly.io, or a small VPS.
+
+1. Deploy the server contained in `server.js` to your hosting provider. Make sure the environment variable `CORS_ORIGIN` includes the origin of the static site (for GitHub Pages it would be `https://<username>.github.io`).
+2. Update `public/config.js` so that `serverUrl` points to the public URL of the deployed Socket.IO server.
+3. Publish the contents of the `public` folder to your static site. When the page loads, it will connect to the remote Socket.IO backend defined in `config.js`.
+
+Once both pieces are live, your game will be accessible online. For example, if you host the static files at `https://maway2000.github.io/g/`, visiting that page will connect to the backend defined in `public/config.js` and allow multiple players to join.

--- a/public/client.js
+++ b/public/client.js
@@ -1,6 +1,12 @@
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
-const socket = io();
+
+const serverUrl =
+  (typeof window !== 'undefined' && window.GAME_CONFIG && window.GAME_CONFIG.serverUrl) ||
+  undefined;
+const socket = io(serverUrl, {
+  transports: ['websocket', 'polling'],
+});
 
 const state = {
   selfId: null,

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,9 @@
+window.GAME_CONFIG = {
+  /**
+   * When hosting the client separately from the Socket.IO server, set this to the
+   * full URL of the backend, for example:
+   *   serverUrl: 'https://multiplayer-cubes.onrender.com'
+   * Leave as null to use the same origin as the current page.
+   */
+  serverUrl: null,
+};

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,8 @@
     </div>
     <canvas id="game"></canvas>
 
-    <script src="/socket.io/socket.io.js"></script>
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" integrity="sha384-8ZPJuNVOIMj2PwGhG9+B+EOykG18Tp7zrsP59RcY+3UJz2CRsuSK+1bjmRPuq85m" crossorigin="anonymous"></script>
+    <script src="config.js"></script>
     <script src="client.js"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -4,7 +4,16 @@ const { Server } = require('socket.io');
 
 const app = express();
 const server = http.createServer(app);
-const io = new Server(server);
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',').map((origin) => origin.trim())
+  : true;
+
+const io = new Server(server, {
+  cors: {
+    origin: allowedOrigins,
+    methods: ['GET', 'POST'],
+  },
+});
 
 const PORT = process.env.PORT || 3000;
 const WORLD_WIDTH = 800;


### PR DESCRIPTION
## Summary
- load the Socket.IO client from a CDN so the static site can run without the Node server
- add configurable server URL support on the client and document how to deploy the game online
- enable CORS configuration for the Socket.IO backend to accept connections from hosted front-ends

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf4201eb348333850976f8d13a66aa