### PR TITLE
Fix socket.io CDN integrity hash

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,11 @@
     </div>
     <canvas id="game"></canvas>
 
-    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js" integrity="sha384-8ZPJuNVOIMj2PwGhG9+B+EOykG18Tp7zrsP59RcY+3UJz2CRsuSK+1bjmRPuq85m" crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.socket.io/4.7.5/socket.io.min.js"
+      integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO"
+      crossorigin="anonymous"
+    ></script>
     <script src="config.js"></script>
     <script src="client.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- update the socket.io CDN script tag to use the correct integrity hash to match version 4.7.5

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf499d888c833387edcdcadcfecea5