### PR TITLE
Expand world size and add player-centered camera

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,8 +16,8 @@ const io = new Server(server, {
 });
 
 const PORT = process.env.PORT || 3000;
-const WORLD_WIDTH = 800;
-const WORLD_HEIGHT = 600;
+const WORLD_WIDTH = 8000;
+const WORLD_HEIGHT = 6000;
 const PLAYER_SPEED = 200; // units per second
 
 app.use(express.static('public'));


### PR DESCRIPTION
## Summary
- expand the server-side world dimensions to provide a 10x larger play area
- keep the client canvas at the original size while introducing a player-centered camera offset
- render ground grid and players relative to the camera so the map scrolls beneath the centered player

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf702bcee48333bb23c174964c5b07