### PR TITLE
Fix canvas dimensions to 800x600

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -22,6 +22,8 @@ canvas {
   border: 4px solid rgba(0, 0, 0, 0.2);
   border-radius: 12px;
   background: linear-gradient(180deg, #9be7ff 0%, #b8f2e6 35%, #fff 100%);
+  width: 800px;
+  height: 600px;
   max-width: calc(100vw - 2rem);
   max-height: calc(100vh - 12rem);
 }


### PR DESCRIPTION
## Summary
- set the canvas element to render at a consistent 800x600 size to match the intended screen view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf7291c11c833389e1062c53adab47