### PR TITLE
Make canvas full screen

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -14,7 +14,10 @@ const VIEW_HEIGHT = 600;
 const state = {
   selfId: null,
   world: { width: VIEW_WIDTH, height: VIEW_HEIGHT },
-  view: { width: VIEW_WIDTH, height: VIEW_HEIGHT },
+  view: {
+    width: typeof window !== 'undefined' ? window.innerWidth : VIEW_WIDTH,
+    height: typeof window !== 'undefined' ? window.innerHeight : VIEW_HEIGHT,
+  },
   players: new Map(),
   circles: new Map(),
   pressed: new Set(),
@@ -46,6 +49,16 @@ const selectionState = {
 function resizeCanvas() {
   canvas.width = state.view.width;
   canvas.height = state.view.height;
+}
+
+function updateViewSize() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  state.view.width = window.innerWidth;
+  state.view.height = window.innerHeight;
+  resizeCanvas();
 }
 
 function getCamera() {
@@ -336,7 +349,7 @@ socket.on('init', ({ selfId, world, players, circles }) => {
   state.players = new Map(players.map((p) => [p.id, p]));
   state.circles = new Map((circles || []).map((circle) => [circle.id, circle]));
   state.selectedCircleIds = new Set();
-  resizeCanvas();
+  updateViewSize();
   render();
 });
 
@@ -600,5 +613,12 @@ canvas.addEventListener('mouseleave', handleMouseUp);
 canvas.addEventListener('contextmenu', handleContextMenu);
 window.addEventListener('mouseup', handleMouseUp);
 window.addEventListener('blur', handleWindowBlur);
+
+window.addEventListener('resize', () => {
+  updateViewSize();
+  render();
+});
+
+updateViewSize();
 
 window.requestAnimationFrame(gameLoop);

--- a/public/style.css
+++ b/public/style.css
@@ -5,25 +5,31 @@
 
 body {
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   background: radial-gradient(circle at top, #fdfcdc, #fee1c7);
   min-height: 100vh;
+  overflow: hidden;
 }
 
 .hud {
+  position: fixed;
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
   text-align: center;
-  margin: 1rem 0;
   color: #2b2d42;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  backdrop-filter: blur(4px);
+  background: rgba(255, 255, 255, 0.65);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
 }
 
 canvas {
-  border: 4px solid rgba(0, 0, 0, 0.2);
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  box-sizing: border-box;
+  border: 4px solid rgba(0, 0, 0, 0.12);
   border-radius: 12px;
   background: linear-gradient(180deg, #9be7ff 0%, #b8f2e6 35%, #fff 100%);
-  width: 800px;
-  height: 600px;
-  max-width: calc(100vw - 2rem);
-  max-height: calc(100vh - 12rem);
 }


### PR DESCRIPTION
## Summary
- update the HUD and canvas styling so the playfield fills the entire viewport while keeping the HUD readable
- resize the client view to match the browser window on load and whenever the window size changes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf9288bdb88333a291fdcab767da44