### PR TITLE
Fix selecting friendly circles with primary mouse button

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -609,6 +609,15 @@ function handleMouseDown(event) {
 
   if (isPrimaryButton && circle && circle.ownerId === state.selfId && !shiftPressed) {
     state.selectedCircleIds = new Set([circle.id]);
+
+    dragState.circleId = circle.id;
+    dragState.dragging = false;
+    dragState.offsetX = circle.x - world.x;
+    dragState.offsetY = circle.y - world.y;
+    dragState.startMouseX = local.x;
+    dragState.startMouseY = local.y;
+    dragState.lastSent = 0;
+
     setCursorForWorldPosition(world.x, world.y);
     event.preventDefault();
     return;


### PR DESCRIPTION
## Summary
- initialize drag state when primary-clicking an owned circle
- allow subsequent handlers to drag or mark the selected unit

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfae07a0c48333b71a41544cfc1f8d