### PR TITLE
Enable left-click drag selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,7 @@
       <h1>Multiplayer Cubes</h1>
       <p>Use WASD or arrow keys to move your cube around the arena.</p>
       <p>Open this page in another tab to see another player join in real time.</p>
+      <p>Left-click and drag to select your circles, then left-click to send them to a location.</p>
     </div>
     <canvas id="game"></canvas>
 


### PR DESCRIPTION
## Summary
- allow primary mouse drags on the world to start box selection without requiring Shift
- increase the drag threshold and adjust the cursor logic to support the new interaction
- document the left-click drag selection workflow in the HUD instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfbd4ee40c8333aec6a0539eaf0122