### PR TITLE
Add start screen for player name entry

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,25 @@
       <p>Open this page in another tab to see another player join in real time.</p>
       <p>Left-click and drag to select your circles, then left-click to send them to a location.</p>
     </div>
+    <div class="start-screen" id="start-screen" role="dialog" aria-modal="true" aria-labelledby="start-title">
+      <form class="start-screen__form" id="start-form">
+        <h2 class="start-screen__title" id="start-title">Ready to play?</h2>
+        <label class="start-screen__label" for="player-name">Enter your name</label>
+        <input
+          id="player-name"
+          name="player-name"
+          class="start-screen__input"
+          type="text"
+          maxlength="20"
+          autocomplete="name"
+          placeholder="Your name"
+          required
+        />
+        <p class="start-screen__hint">Your name will appear above your cube.</p>
+        <p class="start-screen__error" id="start-error" aria-live="polite"></p>
+        <button type="submit" class="start-screen__button">Start game</button>
+      </form>
+    </div>
     <canvas id="game"></canvas>
 
     <script

--- a/public/style.css
+++ b/public/style.css
@@ -33,3 +33,93 @@ canvas {
   border-radius: 12px;
   background: linear-gradient(180deg, #9be7ff 0%, #b8f2e6 35%, #fff 100%);
 }
+
+.start-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: rgba(17, 24, 39, 0.55);
+  backdrop-filter: blur(6px);
+  z-index: 10;
+}
+
+.start-screen.hidden {
+  display: none;
+}
+
+.start-screen__form {
+  width: min(420px, 100%);
+  padding: 2.5rem 2rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.45);
+  text-align: center;
+  color: #1d3557;
+}
+
+.start-screen__title {
+  margin: 0 0 1rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.start-screen__label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.start-screen__input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 2px solid rgba(29, 53, 87, 0.2);
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease;
+}
+
+.start-screen__input:focus {
+  outline: none;
+  border-color: #457b9d;
+  box-shadow: 0 0 0 3px rgba(69, 123, 157, 0.2);
+}
+
+.start-screen__hint {
+  margin: 0.75rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(29, 53, 87, 0.75);
+}
+
+.start-screen__error {
+  min-height: 1.25rem;
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  color: #d62828;
+}
+
+.start-screen__button {
+  margin-top: 1.5rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #457b9d, #1d3557);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.start-screen__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(17, 24, 39, 0.2);
+}
+
+.start-screen__button:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 16px rgba(17, 24, 39, 0.2);
+}

--- a/server.js
+++ b/server.js
@@ -26,6 +26,8 @@ const CIRCLE_INTERVAL_MS = 1000;
 const PLAYER_COLLISION_PADDING = 1;
 const CIRCLE_COLLISION_PADDING = 0.5;
 const MAX_COLLISION_ITERATIONS = 6;
+const PLAYER_NAME_MAX_LENGTH = 20;
+const DEFAULT_PLAYER_NAME = 'Player';
 
 app.use(express.static('public'));
 
@@ -217,6 +219,7 @@ io.on('connection', (socket) => {
     x: Math.random() * (WORLD_WIDTH - 50) + 25,
     y: Math.random() * (WORLD_HEIGHT - 50) + 25,
     color: randomColor(),
+    name: DEFAULT_PLAYER_NAME,
   };
   players.set(socket.id, spawn);
 
@@ -250,6 +253,27 @@ io.on('connection', (socket) => {
 
     players.set(socket.id, player);
     io.emit('playerMoved', player);
+  });
+
+  socket.on('setName', ({ name }) => {
+    const player = players.get(socket.id);
+    if (!player || typeof name !== 'string') {
+      return;
+    }
+
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const sanitized = trimmed.slice(0, PLAYER_NAME_MAX_LENGTH);
+    if (player.name === sanitized) {
+      return;
+    }
+
+    player.name = sanitized;
+    players.set(socket.id, player);
+    io.emit('playerUpdated', player);
   });
 
   socket.on('markCircle', ({ circleId, marked }) => {


### PR DESCRIPTION
## Summary
- add a start screen overlay where players can enter their name before joining the game
- style the overlay to match the existing aesthetic and focus the player on the name prompt
- update the client and server to store, broadcast, and render player display names once submitted

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68cfcd65eff0833396bd85ec36c57b68