### PR TITLE
Preserve player name after movement updates

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -653,7 +653,20 @@ socket.on('playerJoined', (player) => {
 });
 
 socket.on('playerMoved', (player) => {
-  state.players.set(player.id, player);
+  if (!player || typeof player.id !== 'string') {
+    return;
+  }
+
+  const existingPlayer = state.players.get(player.id);
+  const mergedPlayer = { ...(existingPlayer || {}), ...player };
+
+  if (existingPlayer && typeof existingPlayer.name === 'string') {
+    mergedPlayer.name = existingPlayer.name;
+  } else if (player.id === state.selfId && typeof state.playerName === 'string') {
+    mergedPlayer.name = state.playerName;
+  }
+
+  state.players.set(player.id, mergedPlayer);
 });
 
 socket.on('playerLeft', (playerId) => {


### PR DESCRIPTION
## Summary
- keep existing player names on the client when movement updates arrive
- fall back to the locally entered name for the current user when no existing record is available
- guard against malformed movement payloads before updating the player map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfd302d7a48333a156a32c84ee5368