### PR TITLE
Ensure player names persist after move updates

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -660,9 +660,20 @@ socket.on('playerMoved', (player) => {
   const existingPlayer = state.players.get(player.id);
   const mergedPlayer = { ...(existingPlayer || {}), ...player };
 
-  if (existingPlayer && typeof existingPlayer.name === 'string') {
+  const incomingName =
+    player && typeof player.name === 'string' ? player.name.trim() : '';
+  const existingName =
+    existingPlayer && typeof existingPlayer.name === 'string'
+      ? existingPlayer.name.trim()
+      : '';
+  const selfName =
+    typeof state.playerName === 'string' ? state.playerName.trim() : '';
+
+  if (incomingName) {
+    mergedPlayer.name = player.name;
+  } else if (existingName) {
     mergedPlayer.name = existingPlayer.name;
-  } else if (player.id === state.selfId && typeof state.playerName === 'string') {
+  } else if (player.id === state.selfId && selfName) {
     mergedPlayer.name = state.playerName;
   }
 


### PR DESCRIPTION
## Summary
- ensure player objects keep their assigned names when handling move updates
- prefer incoming non-empty names and fall back to stored or local names for the self player

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cfd659525883338f0074b04f658a8b