### PR TITLE
Remove HUD instructions overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,12 +7,6 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="hud">
-      <h1>Multiplayer Cubes</h1>
-      <p>Use WASD or arrow keys to move your cube around the arena.</p>
-      <p>Open this page in another tab to see another player join in real time.</p>
-      <p>Left-click and drag to select your circles, then left-click to send them to a location.</p>
-    </div>
     <div class="start-screen" id="start-screen" role="dialog" aria-modal="true" aria-labelledby="start-title">
       <form class="start-screen__form" id="start-form">
         <h2 class="start-screen__title" id="start-title">Ready to play?</h2>

--- a/public/style.css
+++ b/public/style.css
@@ -10,20 +10,6 @@ body {
   overflow: hidden;
 }
 
-.hud {
-  position: fixed;
-  top: 1.5rem;
-  left: 50%;
-  transform: translateX(-50%);
-  text-align: center;
-  color: #2b2d42;
-  padding: 0.75rem 1.5rem;
-  border-radius: 999px;
-  backdrop-filter: blur(4px);
-  background: rgba(255, 255, 255, 0.65);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
-}
-
 canvas {
   display: block;
   width: 100vw;


### PR DESCRIPTION
## Summary
- remove the HUD overlay that displayed gameplay instructions
- clean up unused CSS styles for the removed HUD element

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfd929e45883339ed25f52bbb9ae02