### PR TITLE
Fix player name synchronization when join events race with updates

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -641,7 +641,25 @@ function handleSocketInit({ selfId, world, players, circles }) {
 }
 
 function handleSocketPlayerJoined(player) {
-  state.players.set(player.id, player);
+  if (!player || typeof player.id !== 'string') {
+    return;
+  }
+
+  const existingPlayer = state.players.get(player.id);
+  const mergedPlayer = { ...(existingPlayer || {}), ...player };
+
+  const incomingName =
+    player && typeof player.name === 'string' ? player.name.trim() : '';
+  const existingName =
+    existingPlayer && typeof existingPlayer.name === 'string'
+      ? existingPlayer.name.trim()
+      : '';
+
+  if (!incomingName && existingName) {
+    mergedPlayer.name = existingPlayer.name;
+  }
+
+  state.players.set(player.id, mergedPlayer);
 }
 
 function handleSocketConnect() {


### PR DESCRIPTION
## Summary
- merge existing player data when `playerJoined` events arrive without a name
- preserve previously known names so join broadcasts cannot overwrite server updates

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68cfea1079248333ac3115d27d5f8700