### PR TITLE
Remove fallback player identifier display

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -496,8 +496,9 @@ function drawPlayers() {
     ctx.font = '16px sans-serif';
     ctx.textAlign = 'center';
     const rawName = typeof player.name === 'string' ? player.name.trim() : '';
-    const displayName = rawName || player.id.slice(0, 5);
-    ctx.fillText(displayName, centerPoint.x, centerPoint.y - size * state.camera.verticalScale - 10);
+    if (rawName) {
+      ctx.fillText(rawName, centerPoint.x, centerPoint.y - size * state.camera.verticalScale - 10);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- stop rendering placeholder socket ID fragments for unnamed players
- only draw labels when a trimmed player-provided name is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff54f36308333983e41bed3e60760