### PR TITLE
Improve player name legibility

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -492,19 +492,49 @@ function drawPlayers() {
       ctx.stroke();
     }
 
-    ctx.font = '16px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
     const rawName = typeof player.name === 'string' ? player.name.trim() : '';
     if (rawName) {
-      const labelY = centerPoint.y - size * state.camera.verticalScale - 12;
+      ctx.save();
+      ctx.font = '16px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
 
-      ctx.lineWidth = 4;
-      ctx.strokeStyle = 'rgba(0, 0, 0, 0.6)';
+      const textMetrics = ctx.measureText(rawName);
+      const textWidth = textMetrics.width;
+      const textHeight =
+        (textMetrics.actualBoundingBoxAscent || 0) +
+          (textMetrics.actualBoundingBoxDescent || 0) ||
+        16;
+      const paddingX = 8;
+      const paddingY = 4;
+      const offset = size * state.camera.verticalScale + 14;
+
+      let labelY = centerPoint.y - offset;
+      const topEdge = labelY - textHeight / 2 - paddingY;
+      if (topEdge < 0) {
+        labelY = centerPoint.y + offset;
+      }
+      const bottomEdge = labelY + textHeight / 2 + paddingY;
+      const maxLabelY = canvas.height - (textHeight / 2 + paddingY);
+      if (bottomEdge > canvas.height) {
+        labelY = Math.max(textHeight / 2 + paddingY, Math.min(maxLabelY, labelY));
+      }
+
+      const boxWidth = textWidth + paddingX * 2;
+      const boxHeight = textHeight + paddingY * 2;
+      const boxX = centerPoint.x - boxWidth / 2;
+      const boxY = labelY - boxHeight / 2;
+
+      ctx.fillStyle = 'rgba(15, 23, 42, 0.65)';
+      ctx.fillRect(boxX, boxY, boxWidth, boxHeight);
+
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = 'rgba(15, 23, 42, 0.85)';
       ctx.strokeText(rawName, centerPoint.x, labelY);
 
       ctx.fillStyle = '#f8fafc';
       ctx.fillText(rawName, centerPoint.x, labelY);
+      ctx.restore();
     }
   });
 }


### PR DESCRIPTION
## Summary
- ensure player nameplates stay within the viewport by flipping below the cube when there is no space above
- draw a semi-transparent backing behind each name for better contrast

## Testing
- npm start (manually verified in browser)


------
https://chatgpt.com/codex/tasks/task_e_68d05dc4638483338abf05552a6869f8