### PR TITLE
Update socket handshake name after player rename

### DIFF
--- a/server.js
+++ b/server.js
@@ -283,6 +283,12 @@ io.on('connection', (socket) => {
 
     player.name = sanitized;
     players.set(socket.id, player);
+
+    if (!socket.handshake.auth || typeof socket.handshake.auth !== 'object') {
+      socket.handshake.auth = {};
+    }
+    socket.handshake.auth.name = sanitized;
+
     io.emit('playerUpdated', player);
   });
 


### PR DESCRIPTION
## Summary
- update the setName handler to keep socket.handshake.auth.name in sync with the player's sanitized nickname

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0c8763dc4833397bccb3c803bcda3