### PR TITLE
Add Mars landing screen with start transition

### DIFF
--- a/assets/welcome-to-mars.svg
+++ b/assets/welcome-to-mars.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900">
+  <defs>
+    <linearGradient id="sky" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#f0a36a" />
+      <stop offset="1" stop-color="#9c4d2a" />
+    </linearGradient>
+    <linearGradient id="button" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#f6d992" />
+      <stop offset="1" stop-color="#e6b25a" />
+    </linearGradient>
+    <radialGradient id="sun" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#ffd7a8" stop-opacity="0.95" />
+      <stop offset="1" stop-color="#d47a3d" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="900" fill="url(#sky)" />
+  <circle cx="240" cy="220" r="140" fill="url(#sun)" />
+  <circle cx="940" cy="200" r="110" fill="url(#sun)" />
+  <g fill="#7c3b21" opacity="0.85">
+    <path d="M0 500 Q 120 460 240 500 T 480 500 T 720 520 T 960 500 T 1200 520 V900 H0 Z" />
+    <path d="M0 560 Q 160 520 320 560 T 640 560 T 960 580 T 1200 560 V900 H0 Z" fill="#a34f29" />
+  </g>
+  <g fill="#49271c" opacity="0.85">
+    <path d="M400 600 L460 520 H740 L780 560 H820 L840 600 Z" />
+    <rect x="470" y="470" width="220" height="60" rx="10" />
+    <rect x="520" y="420" width="80" height="60" rx="12" />
+  </g>
+  <g fill="#22130f">
+    <circle cx="470" cy="600" r="60" />
+    <circle cx="730" cy="600" r="60" />
+  </g>
+  <g fill="#3b251d">
+    <circle cx="470" cy="600" r="30" />
+    <circle cx="730" cy="600" r="30" />
+  </g>
+  <g fill="#2c1c17">
+    <rect x="240" y="340" width="120" height="60" rx="10" />
+    <rect x="210" y="350" width="50" height="40" rx="6" />
+    <rect x="360" y="350" width="50" height="40" rx="6" />
+    <rect x="570" y="320" width="120" height="60" rx="10" />
+    <rect x="540" y="330" width="50" height="40" rx="6" />
+    <rect x="690" y="330" width="50" height="40" rx="6" />
+    <rect x="840" y="320" width="120" height="60" rx="10" />
+    <rect x="810" y="330" width="50" height="40" rx="6" />
+    <rect x="960" y="330" width="50" height="40" rx="6" />
+  </g>
+  <g fill="#2f1f1a">
+    <path d="M880 610 Q900 540 930 540 Q970 540 960 600 Q950 660 920 660 Q900 660 880 610 Z" />
+    <circle cx="925" cy="520" r="30" />
+  </g>
+  <text x="50%" y="150" font-family="'Segoe UI', 'DejaVu Sans', sans-serif" font-size="110" font-weight="700" text-anchor="middle" fill="#f9dca8" letter-spacing="0.2em">WELCOME TO</text>
+  <text x="50%" y="250" font-family="'Segoe UI', 'DejaVu Sans', sans-serif" font-size="140" font-weight="700" text-anchor="middle" fill="#f9dca8">MARS</text>
+  <g transform="translate(300 700)">
+    <rect width="600" height="140" rx="60" fill="url(#button)" stroke="#b5722f" stroke-width="8" />
+    <text x="300" y="95" font-family="'Segoe UI', 'DejaVu Sans', sans-serif" font-size="100" font-weight="700" text-anchor="middle" fill="#7a3f19">START</text>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,336 @@
-Heelo
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Welcome to Mars</title>
+    <style>
+      :root {
+        color-scheme: only light;
+        --bg-dark: #1e0f0a;
+        --bg-panel: rgba(36, 20, 15, 0.85);
+        --accent: #f6d992;
+        --accent-strong: #e6b25a;
+        --accent-muted: #c27a3b;
+        --text-primary: #fef4e0;
+        --text-secondary: #f3d2a4;
+        font-family: 'Segoe UI', 'DejaVu Sans', system-ui, -apple-system, BlinkMacSystemFont,
+          'Helvetica Neue', sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, #5a2d1b, #1e0f0a 65%);
+        color: var(--text-primary);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: clamp(1.5rem, 5vw, 3rem);
+      }
+
+      main {
+        width: min(1100px, 100%);
+      }
+
+      .view {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: clamp(2rem, 5vw, 3.5rem);
+        text-align: center;
+        background: linear-gradient(160deg, rgba(52, 23, 15, 0.7), rgba(22, 11, 8, 0.9));
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        border-radius: clamp(1.5rem, 4vw, 2.75rem);
+        padding: clamp(2rem, 5vw, 4rem);
+        box-shadow: 0 30px 70px rgba(0, 0, 0, 0.45);
+      }
+
+      .view.hidden {
+        display: none;
+      }
+
+      #landingView img {
+        width: min(90vw, 640px);
+        height: auto;
+        border-radius: clamp(1rem, 3vw, 1.75rem);
+        box-shadow: 0 35px 60px rgba(0, 0, 0, 0.45);
+        border: 4px solid rgba(246, 217, 146, 0.2);
+      }
+
+      #landingView p {
+        max-width: 40ch;
+        line-height: 1.6;
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: clamp(1rem, 2.2vw, 1.25rem);
+      }
+
+      button,
+      .link-button {
+        appearance: none;
+        border: none;
+        font: inherit;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.25em;
+        padding: clamp(0.95rem, 2.2vw, 1.15rem) clamp(2.8rem, 6vw, 4rem);
+        border-radius: 999px;
+        background: linear-gradient(160deg, var(--accent), var(--accent-strong));
+        color: #7a3f19;
+        cursor: pointer;
+        transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
+        box-shadow: 0 20px 40px rgba(230, 178, 90, 0.35);
+      }
+
+      button:hover,
+      button:focus-visible,
+      .link-button:hover,
+      .link-button:focus-visible {
+        transform: translateY(-4px);
+        filter: brightness(1.05);
+        box-shadow: 0 26px 50px rgba(230, 178, 90, 0.5);
+        outline: none;
+      }
+
+      button:active,
+      .link-button:active {
+        transform: translateY(0);
+        box-shadow: 0 16px 30px rgba(230, 178, 90, 0.35);
+      }
+
+      #authView {
+        gap: clamp(2rem, 4vw, 3rem);
+      }
+
+      .auth-header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .auth-header h1 {
+        font-size: clamp(2rem, 5vw, 3rem);
+        margin: 0;
+        letter-spacing: 0.18em;
+      }
+
+      .auth-header p {
+        margin: 0;
+        color: var(--text-secondary);
+        font-size: clamp(1rem, 2vw, 1.2rem);
+        max-width: 55ch;
+      }
+
+      .auth-options {
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+        width: 100%;
+      }
+
+      .auth-card {
+        background: var(--bg-panel);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border-radius: clamp(1.25rem, 3vw, 1.75rem);
+        border: 1px solid rgba(255, 255, 255, 0.07);
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 25px 50px rgba(0, 0, 0, 0.35);
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        text-align: left;
+      }
+
+      .auth-card h2 {
+        margin: 0;
+        font-size: clamp(1.5rem, 3vw, 2rem);
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .auth-card p {
+        margin: 0;
+        color: var(--text-secondary);
+        line-height: 1.5;
+      }
+
+      .auth-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      label span {
+        display: block;
+        font-size: 0.85rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        margin-bottom: 0.35rem;
+        color: rgba(255, 237, 210, 0.8);
+      }
+
+      input[type='email'],
+      input[type='password'],
+      input[type='text'] {
+        width: 100%;
+        padding: 0.85rem 1rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(0, 0, 0, 0.25);
+        color: var(--text-primary);
+        font: inherit;
+        outline: none;
+        transition: border-color 200ms ease, box-shadow 200ms ease;
+      }
+
+      input:focus {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px rgba(246, 217, 146, 0.35);
+      }
+
+      .back-button {
+        background: none;
+        color: var(--accent);
+        letter-spacing: 0.18em;
+        border: 1px solid rgba(246, 217, 146, 0.35);
+        box-shadow: none;
+        padding: 0.75rem 2.75rem;
+      }
+
+      .back-button:hover,
+      .back-button:focus-visible {
+        color: var(--bg-dark);
+        background: rgba(246, 217, 146, 0.1);
+      }
+
+      @media (max-width: 680px) {
+        body {
+          padding: 1.5rem;
+        }
+
+        button,
+        .link-button {
+          letter-spacing: 0.12em;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="view" id="landingView" aria-labelledby="landing-title">
+        <h1 id="landing-title" class="visually-hidden">Welcome to Mars</h1>
+        <img
+          src="assets/welcome-to-mars.svg"
+          alt="Stylized retro illustration welcoming visitors to Mars with rovers and drones"
+        />
+        <p>
+          Prepare for your mission on the Red Planet. Review your credentials and begin your
+          Martian operations briefing when you are ready.
+        </p>
+        <button id="startButton" type="button">Start</button>
+      </section>
+
+      <section class="view hidden" id="authView" aria-labelledby="auth-title">
+        <div class="auth-header">
+          <h1 id="auth-title">Mission Access</h1>
+          <p>
+            Choose your path to the Mars command console. Returning explorers can log in, while new
+            recruits can register for access to the colony systems.
+          </p>
+        </div>
+
+        <div class="auth-options">
+          <article class="auth-card">
+            <h2>Login</h2>
+            <p>Authenticate with your existing credentials to resume your mission planning.</p>
+            <form class="auth-form" id="loginForm">
+              <label>
+                <span>Email</span>
+                <input type="email" name="login-email" autocomplete="email" required />
+              </label>
+              <label>
+                <span>Password</span>
+                <input type="password" name="login-password" autocomplete="current-password" required />
+              </label>
+              <button type="submit">Login</button>
+            </form>
+          </article>
+
+          <article class="auth-card">
+            <h2>Create New</h2>
+            <p>Register a fresh account and join the newest expeditionary team on Mars.</p>
+            <form class="auth-form" id="registerForm">
+              <label>
+                <span>Call sign</span>
+                <input type="text" name="register-name" autocomplete="nickname" required />
+              </label>
+              <label>
+                <span>Email</span>
+                <input type="email" name="register-email" autocomplete="email" required />
+              </label>
+              <label>
+                <span>Password</span>
+                <input type="password" name="register-password" autocomplete="new-password" required />
+              </label>
+              <button type="submit">Create Account</button>
+            </form>
+          </article>
+        </div>
+
+        <button class="back-button" id="backButton" type="button">Back</button>
+      </section>
+    </main>
+
+    <script>
+      const landingView = document.getElementById('landingView');
+      const authView = document.getElementById('authView');
+      const startButton = document.getElementById('startButton');
+      const backButton = document.getElementById('backButton');
+      const loginForm = document.getElementById('loginForm');
+      const registerForm = document.getElementById('registerForm');
+
+      const showAuthView = () => {
+        landingView.classList.add('hidden');
+        authView.classList.remove('hidden');
+        const firstInput = authView.querySelector('input');
+        firstInput?.focus();
+      };
+
+      const showLandingView = () => {
+        authView.classList.add('hidden');
+        landingView.classList.remove('hidden');
+        startButton.focus();
+      };
+
+      startButton.addEventListener('click', showAuthView);
+      backButton.addEventListener('click', showLandingView);
+
+      const handleFakeSubmit = (event) => {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const action = form.id === 'loginForm' ? 'logged in' : 'registered';
+        alert(`Demo only: you would have ${action}.`);
+      };
+
+      loginForm.addEventListener('submit', handleFakeSubmit);
+      registerForm.addEventListener('submit', handleFakeSubmit);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the placeholder index page with a polished "Welcome to Mars" landing view that highlights the mission briefing artwork
- add a secondary login/create account layout that appears after pressing Start, including accessible forms and back navigation
- include a custom Mars-themed SVG illustration used on the landing screen

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d203841d8c8333a824582f5fb44ea9