### PR TITLE
Add wallpaper preview to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,59 @@
-Heelo
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wallpaper</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #111827;
+        color: #f9fafb;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        padding: 2rem 1.5rem;
+      }
+
+      h1 {
+        margin-bottom: 1.5rem;
+        font-size: clamp(2rem, 5vw, 3rem);
+        font-weight: 600;
+        text-align: center;
+      }
+
+      figure {
+        margin: 0;
+        width: min(100%, 960px);
+      }
+
+      img {
+        display: block;
+        width: 100%;
+        border-radius: 1.25rem;
+        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.7);
+      }
+
+      figcaption {
+        margin-top: 0.75rem;
+        text-align: center;
+        font-size: 0.95rem;
+        color: rgba(249, 250, 251, 0.8);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Featured Wallpaper</h1>
+    <figure>
+      <img src="/images/wallpaper" alt="Wallpaper" />
+      <figcaption>Direct preview of the wallpaper file located at <code>/images/wallpaper</code>.</figcaption>
+    </figure>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the bare HTML stub with a styled page that showcases the `/images/wallpaper` asset
- center the wallpaper preview and add descriptive caption text to clarify the source

## Testing
- not run (static HTML page)

------
https://chatgpt.com/codex/tasks/task_e_68d2094b6e048333bf0d1ce4c412c95c