### PR TITLE
Load wallpapers from manifest

### DIFF
--- a/images/wallpapers/manifest.json
+++ b/images/wallpapers/manifest.json
@@ -1,0 +1,8 @@
+[
+  "wallpaper.png",
+  "wallpaper2.png",
+  "wallpaper3.png",
+  "wallpaper4.png",
+  "wallpaper5.png",
+  "wallpaper6.png"
+]

--- a/index.html
+++ b/index.html
@@ -122,7 +122,36 @@
 
         const dedupe = (items) => Array.from(new Set(items));
 
+        const fetchFromManifest = async () => {
+          const manifestUrl = `${imageDirectory}manifest.json`;
+
+          const response = await fetch(manifestUrl, { cache: "no-store" });
+
+          if (!response.ok) {
+            if (response.status === 404) {
+              return null;
+            }
+            throw new Error(`Unable to load the wallpapers manifest (${response.status}).`);
+          }
+
+          const manifest = await response.json();
+
+          if (!Array.isArray(manifest)) {
+            throw new Error("Unexpected wallpapers manifest format.");
+          }
+
+          return manifest
+            .filter((file) => typeof file === "string")
+            .map(normaliseFileName)
+            .filter((file) => isImageFile(file));
+        };
+
         const fetchWallpaperFiles = async () => {
+          const manifestFiles = await fetchFromManifest();
+          if (manifestFiles && manifestFiles.length > 0) {
+            return manifestFiles;
+          }
+
           const response = await fetch(imageDirectory, { cache: "no-store" });
 
           if (!response.ok) {


### PR DESCRIPTION
## Summary
- add a static wallpapers manifest so the slideshow can discover files on GitHub Pages
- prefer loading wallpapers from the manifest and fall back to the older directory listing logic

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d213d5dea48333adee1921687f4266