### PR TITLE
Adjust wallpaper fade duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         object-fit: cover;
         border-radius: inherit;
         opacity: 0;
-        transition: opacity 900ms ease-in-out;
+        transition: opacity 1000ms ease-in-out;
       }
 
       .wallpaper-image.is-visible {
@@ -104,7 +104,7 @@
         const captionElement = document.getElementById("wallpaperCaption");
         const supportedExtensions = [".png", ".jpg", ".jpeg", ".webp", ".gif"];
         const SLIDE_DURATION_MS = 5000;
-        const CROSS_FADE_DURATION_MS = 900;
+        const CROSS_FADE_DURATION_MS = 1000;
 
         const secondaryImageElement = imageElement.cloneNode(false);
         secondaryImageElement.removeAttribute("id");


### PR DESCRIPTION
## Summary
- extend the wallpaper image transition to one second for smoother fades
- align the JavaScript cross-fade duration constant with the CSS transition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d21dc826a883339a1c9cee5e6dde82