### PR TITLE
Delay wallpaper visibility class to start cross-fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,38 +207,42 @@
 
               requestAnimationFrame(() => {
                 nextImageElement.hidden = false;
-                nextImageElement.classList.add("is-visible");
+                nextImageElement.classList.remove("is-visible");
 
-                if (previousImageElement) {
-                  previousImageElement.classList.remove("is-visible");
+                requestAnimationFrame(() => {
+                  nextImageElement.classList.add("is-visible");
 
-                  let transitionCompleted = false;
-                  let fallbackTimeoutId;
+                  if (previousImageElement) {
+                    previousImageElement.classList.remove("is-visible");
 
-                  const markTransitionComplete = () => {
-                    if (transitionCompleted) {
-                      return;
-                    }
-                    transitionCompleted = true;
-                    if (fallbackTimeoutId) {
-                      window.clearTimeout(fallbackTimeoutId);
-                    }
+                    let transitionCompleted = false;
+                    let fallbackTimeoutId;
+
+                    const markTransitionComplete = () => {
+                      if (transitionCompleted) {
+                        return;
+                      }
+                      transitionCompleted = true;
+                      if (fallbackTimeoutId) {
+                        window.clearTimeout(fallbackTimeoutId);
+                      }
+                      finaliseTransition();
+                    };
+
+                    previousImageElement.addEventListener(
+                      "transitionend",
+                      markTransitionComplete,
+                      { once: true }
+                    );
+
+                    fallbackTimeoutId = window.setTimeout(
+                      markTransitionComplete,
+                      CROSS_FADE_DURATION_MS + 120
+                    );
+                  } else {
                     finaliseTransition();
-                  };
-
-                  previousImageElement.addEventListener(
-                    "transitionend",
-                    markTransitionComplete,
-                    { once: true }
-                  );
-
-                  fallbackTimeoutId = window.setTimeout(
-                    markTransitionComplete,
-                    CROSS_FADE_DURATION_MS + 120
-                  );
-                } else {
-                  finaliseTransition();
-                }
+                  }
+                });
               });
             };
 


### PR DESCRIPTION
## Summary
- delay applying the visibility class on the incoming wallpaper by an extra animation frame so it renders once at zero opacity
- keep previous wallpaper fade-out logic and transition cleanup intact while ensuring the aspect ratio updates still run

## Testing
- Manually verified the slideshow in a browser to confirm the cross-fade runs smoothly

------
https://chatgpt.com/codex/tasks/task_e_68d220d48b008333a60c4956d8575405