### PR TITLE
Remove wallpaper manifest to auto-detect images

### DIFF
--- a/images/wallpapers/manifest.json
+++ b/images/wallpapers/manifest.json
@@ -1,8 +1,0 @@
-[
-  "wallpaper.png",
-  "wallpaper2.png",
-  "wallpaper3.png",
-  "wallpaper4.png",
-  "wallpaper5.png",
-  "wallpaper6.png"
-]


### PR DESCRIPTION
## Summary
- remove the wallpaper manifest so the slideshow enumerates the directory contents automatically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d22a1979ec83339dd703772f53e8ca