### PR TITLE
Add wallpapers manifest and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Wallpaperz
+
+This repository hosts a minimalist static page that showcases random wallpapers from the `images/wallpapers/` directory.
+
+## Updating wallpapers
+
+When adding or removing wallpapers, make sure `images/wallpapers/manifest.json` lists the exact set of image filenames (paths relative to `images/wallpapers/`). The page uses this manifest at runtime, so forgetting to update it will prevent new wallpapers from appearing when the site is deployed to a server that does not expose directory listings.
+
+A quick way to regenerate the manifest after changing the wallpapers is to run:
+
+```sh
+python - <<'PY'
+import json
+from pathlib import Path
+base = Path('images/wallpapers')
+print(json.dumps(sorted(p.name for p in base.iterdir() if p.is_file()), indent=2))
+PY
+```
+
+Copy the output into `images/wallpapers/manifest.json` and commit both the updated manifest and the wallpapers together.

--- a/images/wallpapers/manifest.json
+++ b/images/wallpapers/manifest.json
@@ -1,0 +1,17 @@
+[
+  "7.png",
+  "8.png",
+  "9.png",
+  "10.png",
+  "11.png",
+  "12.png",
+  "13.png",
+  "14.png",
+  "15.png",
+  "wallpaper.png",
+  "wallpaper2.png",
+  "wallpaper3.png",
+  "wallpaper4.png",
+  "wallpaper5.png",
+  "wallpaper6.png"
+]


### PR DESCRIPTION
## Summary
- add a wallpapers manifest consumed by the slideshow before attempting to list the directory
- document the need to keep the manifest in sync with the wallpapers and provide a snippet to regenerate it

## Testing
- Started a Python SimpleHTTPServer variant with directory listings disabled and confirmed the page loads wallpapers from the manifest


------
https://chatgpt.com/codex/tasks/task_e_68d230d692148333ac8e133fcf438290