### PR TITLE
Rename project branding to Dust Nova

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wallpaperz
+# Dust Nova
 
 This repository hosts a minimalist static page that showcases random wallpapers from the `images/wallpapers/` directory.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Wallpaperz</title>
+    <title>Dust Nova</title>
     <style>
       * {
         box-sizing: border-box;

--- a/pages/login.html
+++ b/pages/login.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Login · Wallpaperz</title>
+    <title>Login · Dust Nova</title>
     <style>
       :root {
         color-scheme: dark;
@@ -178,7 +178,7 @@
             <path d="M4 10.5 16 4l12 6.5v11L16 28 4 21.5Z" />
             <path d="M16 28V4" />
           </svg>
-          Wallpaperz
+          Dust Nova
         </span>
         <h1>Welcome back</h1>
         <p class="description">

--- a/pages/register.html
+++ b/pages/register.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Create account · Wallpaperz</title>
+    <title>Create account · Dust Nova</title>
     <style>
       :root {
         color-scheme: dark;
@@ -171,7 +171,7 @@
             <path d="M4 10.5 16 4l12 6.5v11L16 28 4 21.5Z" />
             <path d="M16 28V4" />
           </svg>
-          Wallpaperz
+          Dust Nova
         </span>
         <h1>Create your account</h1>
         <p class="description">


### PR DESCRIPTION
## Summary
- update the site and supporting docs to use the new Dust Nova name instead of Wallpaperz

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2428463bc833397eccd3c8acc2d21