### PR TITLE
Embed login panel in monitor illustration

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,29 +25,62 @@
 
       .auth-actions {
         position: fixed;
-        inset: 0 0 0 auto;
+        inset: auto 2rem 2rem auto;
         display: flex;
-        align-items: center;
+        align-items: flex-end;
         justify-content: flex-end;
-        padding: 2rem;
         pointer-events: none;
         opacity: 1;
         transition: opacity 300ms ease;
       }
 
-      .auth-actions__content {
-        width: min(24rem, 90vw);
-        border-radius: 1.25rem;
+      .auth-monitor {
+        position: relative;
+        display: inline-flex;
+        width: min(32rem, 42vw);
+        aspect-ratio: 1024 / 1536;
+        pointer-events: auto;
+      }
+
+      .auth-monitor__image {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        filter: drop-shadow(0 25px 45px rgba(15, 23, 42, 0.5));
+      }
+
+      .auth-monitor__screen {
+        position: absolute;
+        inset: 19% 16% 44% 17%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: 1.5rem;
+        padding: 1.75rem 1.5rem;
         background: linear-gradient(
-          155deg,
-          rgba(15, 23, 42, 0.58) 0%,
-          rgba(30, 41, 59, 0.44) 100%
+          150deg,
+          rgba(15, 23, 42, 0.7) 0%,
+          rgba(30, 41, 59, 0.55) 100%
         );
-        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.3);
-        backdrop-filter: blur(10px);
-        padding: 2.5rem 2.25rem;
+        border-radius: 1.75rem;
+        box-shadow: inset 0 0 25px rgba(99, 102, 241, 0.18);
+        backdrop-filter: blur(14px);
+      }
+
+      .auth-actions__content {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
         pointer-events: auto;
         transition: transform 300ms ease, opacity 300ms ease;
+      }
+
+      .auth-actions__title {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        color: #e2e8f0;
       }
 
       .auth-actions.is-hidden {
@@ -69,7 +102,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        padding: 0.85rem 1.25rem;
+        padding: 0.9rem 1rem;
         border-radius: 9999px;
         border: 1px solid rgba(148, 163, 184, 0.4);
         color: #f8fafc;
@@ -118,12 +151,16 @@
 
       @media (max-width: 1024px) {
         .auth-actions {
-          align-items: flex-end;
-          padding: 1.75rem;
+          inset: auto 1.5rem 1.5rem auto;
         }
 
-        .auth-actions__content {
-          padding: 2rem 1.75rem;
+        .auth-monitor {
+          width: min(28rem, 55vw);
+        }
+
+        .auth-monitor__screen {
+          inset: 19.5% 17% 44% 18%;
+          padding: 1.5rem 1.25rem;
         }
       }
 
@@ -134,12 +171,20 @@
 
         .auth-actions {
           position: static;
-          padding: 1.5rem;
+          inset: auto;
+          margin: 2.5rem auto 2rem;
           justify-content: center;
+          max-width: none;
         }
 
-        .auth-actions__content {
-          width: min(28rem, 100%);
+        .auth-monitor {
+          width: min(24rem, 100%);
+          aspect-ratio: 3 / 4.5;
+        }
+
+        .auth-monitor__screen {
+          inset: 17% 12% 42% 13%;
+          padding: 1.5rem;
         }
 
         .wallpaper-frame {
@@ -202,15 +247,27 @@
       </div>
     </figure>
     <aside class="auth-actions" aria-label="Account options">
-      <div class="auth-actions__content">
-        <div class="auth-actions__buttons" role="group" aria-label="Authentication actions">
-          <a class="auth-actions__button auth-actions__button--primary" href="pages/login.html"
-            >Log in</a
-          >
-          <a class="auth-actions__button" href="pages/register.html">Register</a>
-          <button class="auth-actions__button auth-actions__button--ghost" type="button">
-            Continue as guest
-          </button>
+      <div class="auth-monitor">
+        <img
+          class="auth-monitor__image"
+          src="images/index/monitor.png"
+          alt="Futuristic workstation with glowing monitor"
+          decoding="async"
+          loading="lazy"
+        />
+        <div class="auth-monitor__screen">
+          <div class="auth-actions__content">
+            <h2 class="auth-actions__title">Dust Nova Access</h2>
+            <div class="auth-actions__buttons" role="group" aria-label="Authentication actions">
+              <a class="auth-actions__button auth-actions__button--primary" href="pages/login.html"
+                >Log in</a
+              >
+              <a class="auth-actions__button" href="pages/register.html">Register</a>
+              <button class="auth-actions__button auth-actions__button--ghost" type="button">
+                Continue as guest
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- add the new monitor illustration to the index page and anchor it to the bottom-right corner
- embed the authentication CTA within the monitor screen with refreshed styling
- tune responsive breakpoints so the login buttons stay framed inside the computer display

## Testing
- Not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68d25a61f2a88333bac58443ffc234bd