### PR TITLE
Add Dust Nova story overview to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,33 @@
         gap: 0.75rem;
       }
 
+      .auth-actions__info {
+        margin-top: 2rem;
+        padding: 1.25rem;
+        border-radius: 1rem;
+        background: rgba(15, 23, 42, 0.35);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      }
+
+      .auth-actions__info h2 {
+        margin: 0 0 0.75rem;
+        font-size: 1.25rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        color: #e0f2fe;
+      }
+
+      .auth-actions__info p {
+        margin: 0 0 0.85rem;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.88);
+      }
+
+      .auth-actions__info p:last-child {
+        margin-bottom: 0;
+      }
+
       .auth-actions__button {
         display: inline-flex;
         align-items: center;
@@ -211,6 +238,28 @@
           <button class="auth-actions__button auth-actions__button--ghost" type="button">
             Continue as guest
           </button>
+        </div>
+        <div class="auth-actions__info">
+          <h2>Welcome to Dust Nova</h2>
+          <p>
+            In the not-so-distant future, humanity has set its sights on Mars, driven by the
+            promise of untapped resources and new frontiers. As a pioneering miner, you are part of
+            the Mars Frontier Initiative—an elite team tasked with extracting precious minerals
+            scattered across the planet’s harsh, unpredictable terrain.
+          </p>
+          <p>
+            Your mission is more than mining. Establish and maintain resource outposts, research
+            advanced technologies, and defend key mining sites from rivals and Martian predators.
+            Exploration is key—hidden beneath the red dust are rare minerals, ancient ruins, and
+            abandoned settlements that hold clues to Mars’ mysterious past.
+          </p>
+          <p>
+            Alliances can turn the tide. Trade with fellow miners, or sabotage competitors to gain an
+            edge. Your choices shape the future of Mars colonization. Will you rise as a legendary
+            prospector, known for your cunning and courage, or be swallowed by the planet’s
+            unforgiving landscape? The red planet awaits—adapt, fight, and survive to claim your
+            fortune.
+          </p>
         </div>
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- add a welcome section to the landing page with the Dust Nova narrative overview
- style the new section to fit the existing glassmorphism aesthetic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d26beeda448333b299869d4a376425