### PR TITLE
Move auth buttons onto monitor display

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,25 +24,35 @@
       }
 
       .auth-actions {
-        position: fixed;
-        bottom: 0;
-        left: 0;
+        position: absolute;
+        top: 17%;
+        right: 10%;
+        bottom: 13%;
+        left: 8%;
         display: flex;
         align-items: flex-end;
-        justify-content: flex-start;
-        padding: 2.5rem;
+        justify-content: center;
         pointer-events: none;
         opacity: 1;
         transition: opacity 300ms ease;
       }
 
       .auth-actions__content {
-        width: auto;
-        border-radius: 0;
-        background: none;
-        box-shadow: none;
-        backdrop-filter: none;
-        padding: 0;
+        display: flex;
+        align-items: flex-end;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        border-radius: 1.25rem;
+        background: linear-gradient(
+          155deg,
+          rgba(15, 23, 42, 0.85) 0%,
+          rgba(15, 23, 42, 0.55) 100%
+        );
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 20px 35px rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(12px);
+        padding: 1.75rem 1.5rem;
         pointer-events: auto;
         transition: transform 300ms ease, opacity 300ms ease;
       }
@@ -60,7 +70,9 @@
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
-        width: min(9rem, 60vw);
+        width: 100%;
+        max-width: 12rem;
+        margin: 0 auto;
       }
 
       .story-card {
@@ -106,6 +118,7 @@
         align-items: center;
         justify-content: center;
         padding: 0.7rem 0.5rem;
+        width: 100%;
         border-radius: 9999px;
         border: 1px solid rgba(148, 163, 184, 0.4);
         color: #f8fafc;
@@ -152,25 +165,34 @@
         color: #f8fafc;
       }
 
-      .monitor-decoration {
+      .monitor-ui {
         position: fixed;
         bottom: 0;
         left: 0;
         width: min(26rem, 40vw);
         max-width: 420px;
+        transform: translate(-10%, 8%);
+        z-index: 1;
+      }
+
+      .monitor-decoration {
+        display: block;
+        width: 100%;
         height: auto;
         pointer-events: none;
         user-select: none;
-        transform: translate(-10%, 8%);
       }
 
       @media (max-width: 1024px) {
         .auth-actions {
-          padding: 2rem;
+          top: 19%;
+          right: 12%;
+          bottom: 15%;
+          left: 10%;
         }
 
         .auth-actions__content {
-          padding: 2rem 1.75rem;
+          padding: 1.5rem 1.25rem;
         }
 
         .story-card {
@@ -181,7 +203,7 @@
           width: auto;
         }
 
-        .monitor-decoration {
+        .monitor-ui {
           width: min(22rem, 45vw);
           transform: translate(-12%, 10%);
         }
@@ -192,13 +214,24 @@
           overflow: auto;
         }
 
+        .monitor-ui {
+          position: static;
+          width: 100%;
+          max-width: none;
+          transform: none;
+          padding: 1.5rem 1.5rem 0;
+        }
+
         .auth-actions {
           position: static;
-          padding: 1.5rem 1.5rem 0;
+          inset: auto;
+          display: flex;
           justify-content: center;
+          pointer-events: auto;
         }
 
         .auth-actions__content {
+          height: auto;
           width: min(28rem, 100%);
         }
 
@@ -272,28 +305,36 @@
         />
       </div>
     </figure>
-    <img
-      class="monitor-decoration"
-      src="images/index/monitor.png"
-      alt="Decorative mission monitor"
-      width="960"
-      height="640"
-      loading="lazy"
-      decoding="async"
-    />
-    <aside class="auth-actions" aria-label="Account options">
-      <div class="auth-actions__content">
-        <div class="auth-actions__buttons" role="group" aria-label="Authentication actions">
-          <a class="auth-actions__button auth-actions__button--primary" href="pages/login.html"
-            >Log in</a
+    <div class="monitor-ui">
+      <img
+        class="monitor-decoration"
+        src="images/index/monitor.png"
+        alt="Decorative mission monitor"
+        width="960"
+        height="640"
+        loading="lazy"
+        decoding="async"
+      />
+      <aside class="auth-actions" aria-label="Account options">
+        <div class="auth-actions__content">
+          <div
+            class="auth-actions__buttons"
+            role="group"
+            aria-label="Authentication actions"
           >
-          <a class="auth-actions__button" href="pages/register.html">Register</a>
-          <button class="auth-actions__button auth-actions__button--ghost" type="button">
-            Continue as guest
-          </button>
+            <a
+              class="auth-actions__button auth-actions__button--primary"
+              href="pages/login.html"
+              >Log in</a
+            >
+            <a class="auth-actions__button" href="pages/register.html">Register</a>
+            <button class="auth-actions__button auth-actions__button--ghost" type="button">
+              Continue as guest
+            </button>
+          </div>
         </div>
-      </div>
-    </aside>
+      </aside>
+    </div>
     <section class="story-card" aria-labelledby="story-card-title">
       <h2 id="story-card-title">Welcome to Dusty Nova</h2>
       <p>


### PR DESCRIPTION
## Summary
- wrap the monitor image and authentication actions in a shared container so the buttons can sit on the display
- restyle the auth action card with a glass-like panel positioned within the monitor screen and stretch buttons to full width
- update responsive rules so the monitor layout still collapses cleanly on tablets and phones

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2f4fa2bdc83339170ddfc868900c6