### PR TITLE
Remove translucent auth panel background

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,18 +55,13 @@
 
       .auth-actions__content {
         width: 100%;
-        border-radius: 0.85rem;
-        background: linear-gradient(
-          155deg,
-          rgba(15, 23, 42, 0.7) 0%,
-          rgba(30, 41, 59, 0.52) 100%
-        );
-        border: 1px solid rgba(148, 163, 184, 0.18);
-        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
-        backdrop-filter: blur(14px);
         padding: 1.25rem 1rem;
         pointer-events: auto;
         transition: transform 300ms ease, opacity 300ms ease;
+        background: none;
+        border: none;
+        box-shadow: none;
+        backdrop-filter: none;
       }
 
       .auth-actions.is-hidden {


### PR DESCRIPTION
## Summary
- remove the translucent background panel from the authentication action area so only the buttons remain visible

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d34d26df2c833395d26279367609ba