### PR TITLE
Center auth screen and add matrix styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,23 +45,61 @@
         right: var(--screen-right);
         bottom: var(--screen-bottom);
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         justify-content: center;
-        padding: 0;
+        padding: 0.75rem;
         pointer-events: none;
         opacity: 1;
         transition: opacity 300ms ease;
       }
 
       .auth-actions__content {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         width: 100%;
-        padding: 1.25rem 1rem;
+        height: 100%;
+        padding: clamp(1.65rem, 3vw, 2.35rem) clamp(1.4rem, 2.4vw, 2rem);
+        border-radius: 1.35rem;
+        background: rgba(3, 7, 18, 0.82);
+        border: 1px solid rgba(52, 211, 153, 0.35);
+        box-shadow: 0 24px 48px rgba(6, 15, 11, 0.6);
+        overflow: hidden;
+        isolation: isolate;
         pointer-events: auto;
         transition: transform 300ms ease, opacity 300ms ease;
-        background: none;
-        border: none;
-        box-shadow: none;
-        backdrop-filter: none;
+        backdrop-filter: blur(3px);
+      }
+
+      .auth-actions__content::before {
+        content: "";
+        position: absolute;
+        inset: -55% -40% -45%;
+        background-image:
+          linear-gradient(180deg, rgba(1, 11, 8, 0.92) 0%, rgba(1, 24, 18, 0.78) 100%),
+          url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%27160%27%20height%3D%27320%27%3E%0A%20%20%3Crect%20width%3D%27160%27%20height%3D%27320%27%20fill%3D%27none%27%2F%3E%0A%20%20%3Cg%20fill%3D%27%2316f89d%27%20font-family%3D%27monospace%27%20font-size%3D%2718%27%20opacity%3D%270.45%27%3E%0A%20%20%20%20%3Ctext%20x%3D%274%27%20y%3D%2720%27%3E1010010110010110%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2720%27%20y%3D%2752%27%3E0010110100100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%278%27%20y%3D%2792%27%3E1101001011010010%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2730%27%20y%3D%27132%27%3E0101100101100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%27-6%27%20y%3D%27172%27%3E1010010110100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2716%27%20y%3D%27212%27%3E0101101001011010%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%272%27%20y%3D%27252%27%3E1001011010010110%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2726%27%20y%3D%27292%27%3E0010110100101101%3C%2Ftext%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E");
+        background-repeat: no-repeat, repeat;
+        background-size: cover, 140px 280px;
+        background-position: center, 0 0;
+        opacity: 0.95;
+        mix-blend-mode: screen;
+        animation: matrix-scroll 12s linear infinite;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .auth-actions__content::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        border: 1px solid rgba(16, 185, 129, 0.35);
+        box-shadow:
+          inset 0 0 24px rgba(16, 185, 129, 0.22),
+          inset 0 0 4px rgba(59, 130, 246, 0.1);
+        pointer-events: none;
+        z-index: 1;
       }
 
       .auth-actions.is-hidden {
@@ -74,10 +112,12 @@
       }
 
       .auth-actions__buttons {
+        position: relative;
         display: flex;
         flex-direction: column;
-        gap: 0.75rem;
+        gap: 0.85rem;
         width: 100%;
+        z-index: 2;
       }
 
       .story-card {
@@ -125,49 +165,59 @@
         padding: 0.7rem 0.5rem;
         width: 100%;
         border-radius: 9999px;
-        border: 1px solid rgba(148, 163, 184, 0.4);
-        color: #f8fafc;
+        border: 1px solid rgba(34, 197, 94, 0.35);
+        color: rgba(226, 252, 239, 0.92);
         text-decoration: none;
         font-size: 0.85rem;
         font-weight: 600;
         letter-spacing: 0.02em;
         transition: transform 0.2s ease, box-shadow 0.2s ease,
-          background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-        background-color: rgba(15, 23, 42, 0.3);
+          background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+          filter 0.2s ease;
+        background-color: rgba(8, 47, 35, 0.6);
         cursor: pointer;
       }
 
       .auth-actions__button:hover,
       .auth-actions__button:focus-visible {
         transform: translateY(-2px);
-        box-shadow: 0 15px 30px rgba(15, 23, 42, 0.45);
+        box-shadow: 0 16px 30px rgba(4, 120, 87, 0.45);
       }
 
       .auth-actions__button:focus-visible {
-        outline: 2px solid rgba(96, 165, 250, 0.8);
+        outline: 2px solid rgba(34, 197, 94, 0.85);
         outline-offset: 3px;
       }
 
       .auth-actions__button--primary {
-        background: linear-gradient(135deg, #6366f1, #8b5cf6);
-        border-color: transparent;
+        background: linear-gradient(135deg, #22c55e, #14b8a6);
+        border-color: rgba(45, 212, 191, 0.65);
+        color: #022c22;
+        box-shadow: 0 0 22px rgba(45, 212, 191, 0.35);
       }
 
       .auth-actions__button--primary:hover,
       .auth-actions__button--primary:focus-visible {
-        background: linear-gradient(135deg, #818cf8, #a855f7);
+        background: linear-gradient(135deg, #34d399, #22d3ee);
+        color: #012c1c;
       }
 
       .auth-actions__button--ghost {
-        background-color: transparent;
-        border-color: rgba(148, 163, 184, 0.3);
-        color: rgba(248, 250, 252, 0.75);
+        background-color: rgba(2, 44, 34, 0.35);
+        border-color: rgba(45, 212, 191, 0.28);
+        color: rgba(209, 250, 229, 0.75);
       }
 
       .auth-actions__button--ghost:hover,
       .auth-actions__button--ghost:focus-visible {
-        background-color: rgba(148, 163, 184, 0.1);
-        color: #f8fafc;
+        background-color: rgba(74, 222, 128, 0.12);
+        color: rgba(240, 253, 244, 0.95);
+      }
+
+      @keyframes matrix-scroll {
+        to {
+          background-position: center, 0 280px;
+        }
       }
 
       .monitor-decoration {
@@ -230,6 +280,7 @@
 
         .auth-actions__content {
           padding: 1.5rem 1.25rem;
+          height: auto;
         }
 
         .story-card {


### PR DESCRIPTION
## Summary
- center the authentication call-to-action within the monitor viewport to use the available space
- wrap the login/register stack in a matrix-inspired animated backdrop with neon trim
- refresh button colors and responsive spacing to match the new theme

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68d35a51b6688333a97fdfee9ea83256