### PR TITLE
Keep matrix effect within monitor frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
       .monitor-station {
         --screen-top: 18%;
         --screen-left: 18%;
-        --screen-right: 16%;
-        --screen-bottom: 32%;
+        --screen-right: 22%;
+        --screen-bottom: 36%;
         position: fixed;
         bottom: 0;
         left: 0;
@@ -75,7 +75,7 @@
       .auth-actions__content::before {
         content: "";
         position: absolute;
-        inset: -55% -40% -45%;
+        inset: -15% -10% -15%;
         background-image:
           linear-gradient(180deg, rgba(1, 11, 8, 0.92) 0%, rgba(1, 24, 18, 0.78) 100%),
           url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%27160%27%20height%3D%27320%27%3E%0A%20%20%3Crect%20width%3D%27160%27%20height%3D%27320%27%20fill%3D%27none%27%2F%3E%0A%20%20%3Cg%20fill%3D%27%2316f89d%27%20font-family%3D%27monospace%27%20font-size%3D%2718%27%20opacity%3D%270.45%27%3E%0A%20%20%20%20%3Ctext%20x%3D%274%27%20y%3D%2720%27%3E1010010110010110%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2720%27%20y%3D%2752%27%3E0010110100100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%278%27%20y%3D%2792%27%3E1101001011010010%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2730%27%20y%3D%27132%27%3E0101100101100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%27-6%27%20y%3D%27172%27%3E1010010110100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2716%27%20y%3D%27212%27%3E0101101001011010%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%272%27%20y%3D%27252%27%3E1001011010010110%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2726%27%20y%3D%27292%27%3E0010110100101101%3C%2Ftext%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E");
@@ -232,8 +232,8 @@
         .monitor-station {
           --screen-top: 15%;
           --screen-left: 20%;
-          --screen-right: 18%;
-          --screen-bottom: 36%;
+          --screen-right: 24%;
+          --screen-bottom: 40%;
           width: min(25rem, 52vw);
           max-width: 420px;
           transform: translate(-12%, 10%);


### PR DESCRIPTION
## Summary
- adjust the monitor overlay offsets so the auth panel sits fully within the screen bounds
- reduce the matrix background pseudo-element inset so the animated digits stay inside the monitor frame
- update the responsive offsets for medium screens to keep the alignment consistent

## Testing
- browser_container.run_playwright_script (visual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d35c8b312483338b382bdf1a34504a