### PR TITLE
Expand auth overlay to match monitor viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,10 @@
       }
 
       .monitor-station {
-        --screen-top: 18%;
-        --screen-left: 18%;
-        --screen-right: 22%;
-        --screen-bottom: 43%;
+        --screen-top: 11.5%;
+        --screen-left: 8.5%;
+        --screen-right: 10.5%;
+        --screen-bottom: 12.5%;
         position: fixed;
         bottom: 0;
         left: 0;
@@ -230,10 +230,10 @@
 
       @media (max-width: 1024px) {
         .monitor-station {
-          --screen-top: 15%;
-          --screen-left: 20%;
-          --screen-right: 24%;
-          --screen-bottom: 46%;
+          --screen-top: 10.5%;
+          --screen-left: 9.5%;
+          --screen-right: 11.5%;
+          --screen-bottom: 13.5%;
           width: min(25rem, 52vw);
           max-width: 420px;
           transform: translate(-12%, 10%);


### PR DESCRIPTION
## Summary
- widen and stretch the authentication overlay so it fills the monitor frame on desktop
- update responsive breakpoints to keep the overlay aligned with the screen on smaller viewports

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d36aa7984883338a70f635a1fa0862