### PR TITLE
Adjust auth panel horizontal offsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
 
       .monitor-station {
         --screen-top: 18%;
-        --screen-left: 18%;
-        --screen-right: 22%;
+        --screen-left: 7%;
+        --screen-right: 40%;
         --screen-bottom: 43%;
         position: fixed;
         bottom: 0;


### PR DESCRIPTION
## Summary
- shift the `.monitor-station` CSS variables so the auth tab sits 7% from the left edge and 40% from the right, matching the updated layout requirements

## Testing
- not run (not required for CSS variable tweak)


------
https://chatgpt.com/codex/tasks/task_e_68d37df50dbc8333b669d958b4f39541