### PR TITLE
Adjust monitor position for partial crop

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         max-width: 440px;
         pointer-events: none;
         user-select: none;
-        transform: translate(-10%, 8%);
+        transform: translate(-10%, 13%);
       }
 
       .auth-actions {
@@ -236,7 +236,7 @@
           --screen-bottom: 46%;
           width: min(25rem, 52vw);
           max-width: 420px;
-          transform: translate(-12%, 10%);
+          transform: translate(-12%, 15%);
         }
 
         .story-card {


### PR DESCRIPTION
## Summary
- shift the monitor decoration downward to hide roughly five percent of its height on large screens
- update the responsive breakpoint transform to keep the same adjustment on medium viewports

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d4abfbcb808333b85ff5c441d2c620