### PR TITLE
Make auth buttons highlight on hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,24 +182,14 @@
       .auth-actions__button:focus-visible {
         transform: translateY(-2px);
         box-shadow: 0 16px 30px rgba(4, 120, 87, 0.45);
+        background: linear-gradient(135deg, #22c55e, #14b8a6);
+        border-color: rgba(45, 212, 191, 0.65);
+        color: #022c22;
       }
 
       .auth-actions__button:focus-visible {
         outline: 2px solid rgba(34, 197, 94, 0.85);
         outline-offset: 3px;
-      }
-
-      .auth-actions__button--primary {
-        background: linear-gradient(135deg, #22c55e, #14b8a6);
-        border-color: rgba(45, 212, 191, 0.65);
-        color: #022c22;
-        box-shadow: 0 0 22px rgba(45, 212, 191, 0.35);
-      }
-
-      .auth-actions__button--primary:hover,
-      .auth-actions__button--primary:focus-visible {
-        background: linear-gradient(135deg, #34d399, #22d3ee);
-        color: #012c1c;
       }
 
       .auth-actions__button--ghost {
@@ -210,8 +200,8 @@
 
       .auth-actions__button--ghost:hover,
       .auth-actions__button--ghost:focus-visible {
-        background-color: rgba(74, 222, 128, 0.12);
-        color: rgba(240, 253, 244, 0.95);
+        background: linear-gradient(135deg, rgba(125, 211, 252, 0.65), rgba(45, 212, 191, 0.65));
+        color: #012c1c;
       }
 
       @keyframes matrix-scroll {
@@ -366,11 +356,7 @@
       <aside class="auth-actions" aria-label="Account options">
         <div class="auth-actions__content">
           <div class="auth-actions__buttons" role="group" aria-label="Authentication actions">
-            <a
-              class="auth-actions__button auth-actions__button--primary"
-              href="pages/login.html"
-              >Log in</a
-            >
+            <a class="auth-actions__button" href="pages/login.html">Log in</a>
             <a class="auth-actions__button" href="pages/register.html">Register</a>
             <button class="auth-actions__button auth-actions__button--ghost" type="button">
               Continue as guest


### PR DESCRIPTION
## Summary
- remove the default "primary" styling from the Log in button so it appears neutral until interacted with
- update hover and focus-visible states so the auth buttons receive the glowing gradient treatment during interaction, including the guest option

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d4ae6d84c48333ac42a404e1e60aac