### PR TITLE
Preload hover sound on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dusty Nova</title>
+    <link rel="preload" as="audio" href="images/index/button_hower.mp3" />
     <style>
       * {
         box-sizing: border-box;
@@ -680,6 +681,7 @@
         if (authButtons.length) {
           const hoverSound = new Audio("images/index/button_hower.mp3");
           hoverSound.preload = "auto";
+          hoverSound.load();
 
           const playHoverSound = () => {
             try {


### PR DESCRIPTION
## Summary
- preload the hover audio file so it starts loading with the page
- explicitly trigger the hover sound's load routine during initialization

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b68544f48333881d4853e7c373be