### PR TITLE
Play hover sound on guest button

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,7 +676,7 @@
         );
 
         const authButtons = document.querySelectorAll(
-          '.auth-actions__button[href$="login.html"], .auth-actions__button[href$="register.html"]'
+          '.auth-actions__button[href$="login.html"], .auth-actions__button[href$="register.html"], .auth-actions__button--ghost'
         );
         if (authButtons.length) {
           const hoverSoundSource = "images/index/button_hower.mp3";


### PR DESCRIPTION
## Summary
- include the Continue as guest button in the hover sound targeting selector so it plays the same audio feedback as Log in and Register

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4bd7cb22c8333b2f790ff1c3d8278