### PR TITLE
Unlock hover audio without click

### DIFF
--- a/index.html
+++ b/index.html
@@ -850,6 +850,35 @@
 
           const hoverSoundReady = prepareHoverSound();
 
+          const attemptUnlockHoverSound = () => {
+            const previousMutedState = hoverSound.muted;
+            hoverSound.muted = true;
+            const unlockPromise = hoverSound.play();
+            const resetHoverSound = () => {
+              hoverSound.pause();
+              hoverSound.currentTime = 0;
+              hoverSound.muted = previousMutedState;
+            };
+
+            if (unlockPromise instanceof Promise) {
+              unlockPromise
+                .then(resetHoverSound)
+                .catch(() => {
+                  hoverSound.muted = previousMutedState;
+                });
+            } else {
+              resetHoverSound();
+            }
+          };
+
+          hoverSoundReady
+            .then(() => {
+              attemptUnlockHoverSound();
+            })
+            .catch(() => {
+              attemptUnlockHoverSound();
+            });
+
           const playHoverSound = () => {
             const startPlayback = () => {
               try {


### PR DESCRIPTION
## Summary
- preload the hover audio and attempt a muted playback to unlock sound without extra clicks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4ca194c10833398fbffaaf3a100c8