### PR TITLE
Gate hover sound playback behind user interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -871,13 +871,48 @@
             }
           };
 
-          hoverSoundReady
-            .then(() => {
-              attemptUnlockHoverSound();
-            })
-            .catch(() => {
-              attemptUnlockHoverSound();
+          let hoverSoundUnlockTriggered = false;
+
+          const triggerHoverSoundUnlock = () => {
+            if (hoverSoundUnlockTriggered) {
+              return;
+            }
+
+            hoverSoundUnlockTriggered = true;
+
+            const performUnlock = () => {
+              try {
+                attemptUnlockHoverSound();
+              } catch (error) {
+                console.error("Unable to unlock hover sound", error);
+              }
+            };
+
+            if (hoverSoundReady) {
+              hoverSoundReady
+                .then(performUnlock)
+                .catch(performUnlock);
+            } else {
+              performUnlock();
+            }
+          };
+
+          const userInteractionEvents = ["pointerdown", "keydown", "touchstart", "click"];
+
+          const handleUserInteraction = () => {
+            userInteractionEvents.forEach((eventName) => {
+              document.removeEventListener(eventName, handleUserInteraction);
             });
+
+            triggerHoverSoundUnlock();
+          };
+
+          userInteractionEvents.forEach((eventName) => {
+            document.addEventListener(eventName, handleUserInteraction, {
+              once: true,
+              passive: true,
+            });
+          });
 
           const playHoverSound = () => {
             const startPlayback = () => {


### PR DESCRIPTION
## Summary
- add user interaction listeners to unlock the hover sound only after a click or key press
- ensure the hover audio element unlock occurs once the preload promise settles for consistent playback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4cc9aa08c83338f93dc7b8922a5b8