### PR TITLE
Fix hover sound activation without initial click

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,6 +817,8 @@
           const hoverSoundSource = "images/index/button_hower.mp3";
           const hoverSound = new Audio();
           hoverSound.preload = "auto";
+          hoverSound.src = hoverSoundSource;
+          hoverSound.load();
 
           const prepareHoverSound = async () => {
             try {
@@ -888,12 +890,16 @@
               }
             };
 
+            performUnlock();
+
             if (hoverSoundReady) {
               hoverSoundReady
-                .then(performUnlock)
-                .catch(performUnlock);
-            } else {
-              performUnlock();
+                .then(() => {
+                  performUnlock();
+                })
+                .catch(() => {
+                  performUnlock();
+                });
             }
           };
 
@@ -915,6 +921,8 @@
           });
 
           const playHoverSound = () => {
+            triggerHoverSoundUnlock();
+
             const startPlayback = () => {
               try {
                 hoverSound.currentTime = 0;
@@ -927,23 +935,27 @@
               }
             };
 
+            startPlayback();
+
             if (hoverSoundReady) {
               hoverSoundReady
                 .then((objectUrl) => {
                   if (objectUrl === null && hoverSound.src !== hoverSoundSource) {
                     hoverSound.src = hoverSoundSource;
                   }
-                  startPlayback();
+                  if (hoverSound.paused) {
+                    startPlayback();
+                  }
                 })
                 .catch(() => {
                   if (!hoverSound.src) {
                     hoverSound.src = hoverSoundSource;
                     hoverSound.load();
                   }
-                  startPlayback();
+                  if (hoverSound.paused) {
+                    startPlayback();
+                  }
                 });
-            } else {
-              startPlayback();
             }
           };
 


### PR DESCRIPTION
## Summary
- load the hover sound immediately so it can be played on the first interaction
- trigger the audio unlock routine on hover and retry unlocking once the preload completes
- start playback synchronously on hover while still retrying if the preload finishes later

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4d16d2d708333bb34974c694ae029