### PR TITLE
Adjust auth modal branding scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,9 +359,13 @@
       }
 
       .auth-card__brand img {
-        height: 2.4rem;
+        height: 4.8rem;
         width: auto;
         display: block;
+      }
+
+      .auth-card[data-auth-view="login"] .auth-card__title {
+        font-size: clamp(1.17rem, 2vw, 1.57rem);
       }
 
       .auth-card__title {


### PR DESCRIPTION
## Summary
- double the brand logo height displayed within the login and register modal tabs
- shrink the login "Welcome back" heading to 2/3 of its previous size for better balance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d52b92cba88333a135b958f142c96f