### PR TITLE
Expand register modal dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,8 +286,8 @@
 
       .auth-modal__dialog {
         position: relative;
-        width: min(100%, 520px);
-        max-height: min(90vh, 720px);
+        width: min(100%, 560px);
+        max-height: min(95vh, 820px);
         transform: translateY(24px);
         transition: transform 280ms ease, opacity 280ms ease;
         opacity: 0;


### PR DESCRIPTION
## Summary
- widen the authentication modal dialog to give the register view more horizontal space
- raise the modal height cap to prevent the register form from requiring a scrollbar

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d531e954d883338c5ba6385bcb4c33