### PR TITLE
Add top center monitor decoration

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,26 @@
         height: 100vh;
       }
 
+      .monitor-top {
+        position: fixed;
+        top: clamp(1.5rem, 4vw, 2.75rem);
+        left: 50%;
+        transform: translateX(-50%);
+        width: min(18rem, 38vw);
+        max-width: 360px;
+        pointer-events: none;
+        user-select: none;
+        z-index: 5;
+      }
+
+      .monitor-top__image {
+        display: block;
+        width: 100%;
+        height: auto;
+        pointer-events: none;
+        user-select: none;
+      }
+
       .monitor-station {
         --screen-top: 18%;
         --screen-left: 11%;
@@ -763,6 +783,11 @@
       }
 
       @media (max-width: 1024px) {
+        .monitor-top {
+          width: min(16rem, 48vw);
+          top: clamp(1rem, 3vw, 2rem);
+        }
+
         .monitor-station {
           --screen-top: 15%;
           --screen-left: 20%;
@@ -789,6 +814,10 @@
       @media (max-width: 720px) {
         body {
           overflow: auto;
+        }
+
+        .monitor-top {
+          display: none;
         }
 
         .monitor-station {
@@ -899,6 +928,17 @@
         />
       </div>
     </figure>
+    <div class="monitor-top" aria-hidden="true">
+      <img
+        class="monitor-top__image"
+        src="images/index/monitor2.png"
+        alt=""
+        width="1024"
+        height="1536"
+        loading="lazy"
+        decoding="async"
+      />
+    </div>
     <div class="monitor-station">
       <img
         class="monitor-decoration"


### PR DESCRIPTION
## Summary
- add a decorative top-center monitor image to the index page
- style the new monitor for desktop and hide it on narrow screens so it doesn't obstruct content

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d55297393c8333848cb3400e1f2adf