### PR TITLE
Add top center monitor image to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,24 @@
         height: 100vh;
       }
 
+      .monitor-header {
+        position: fixed;
+        top: clamp(1.5rem, 5vh, 3rem);
+        left: 50%;
+        transform: translateX(-50%);
+        width: min(28rem, 68vw);
+        max-width: 520px;
+        pointer-events: none;
+        user-select: none;
+        z-index: 4;
+      }
+
+      .monitor-header__image {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+
       .monitor-station {
         --screen-top: 18%;
         --screen-left: 11%;
@@ -899,6 +917,17 @@
         />
       </div>
     </figure>
+    <div class="monitor-header" aria-hidden="true">
+      <img
+        class="monitor-header__image"
+        src="images/index/monitor2.png"
+        alt="Decorative overhead monitor"
+        width="960"
+        height="640"
+        loading="lazy"
+        decoding="async"
+      />
+    </div>
     <div class="monitor-station">
       <img
         class="monitor-decoration"


### PR DESCRIPTION
## Summary
- add a fixed header monitor image that centers the new artwork at the top of the page
- ensure the decorative image is responsive and non-interactive so it layers above the wallpaper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a1d22dc8833399aad876a3c1c3aa