### PR TITLE
Adjust monitor header position and size

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,11 @@
 
       .monitor-header {
         position: fixed;
-        top: clamp(1.5rem, 5vh, 3rem);
+        top: 0;
         left: 50%;
         transform: translateX(-50%);
-        width: min(28rem, 68vw);
-        max-width: 520px;
+        width: min(42rem, 100vw);
+        max-width: 780px;
         pointer-events: none;
         user-select: none;
         z-index: 4;


### PR DESCRIPTION
## Summary
- position the overhead monitor graphic flush with the top of the page
- enlarge the overhead monitor by 1.5x to better fill the viewport

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5cb9fe6008333aa44d62b769f672e