### PR TITLE
Remove overhead monitor image from index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1055,17 +1055,6 @@
         />
       </div>
     </figure>
-    <div class="monitor-header" aria-hidden="true">
-      <img
-        class="monitor-header__image"
-        src="images/index/monitor2.png"
-        alt="Decorative overhead monitor"
-        width="960"
-        height="640"
-        loading="lazy"
-        decoding="async"
-      />
-    </div>
     <div class="monitor-station">
       <img
         class="monitor-decoration"


### PR DESCRIPTION
## Summary
- remove the decorative overhead monitor image so it no longer appears on the index page
- keep the login/register monitor layout untouched

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5d47225988333955cd5fa97fe3e92