### PR TITLE
Adjust auth modal positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,14 +270,16 @@
         position: fixed;
         inset: 0;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: center;
-        padding: clamp(1.5rem, 3vw, 3rem);
+        padding: clamp(2rem, 6vh, 4rem) clamp(1.5rem, 3vw, 3rem)
+          clamp(1.5rem, 3vw, 3rem);
         background: transparent;
         z-index: 40;
         pointer-events: none;
         opacity: 0;
         transition: opacity 280ms ease;
+        overflow-y: auto;
       }
 
       .auth-modal[hidden] {


### PR DESCRIPTION
## Summary
- align the authentication modal to the top of the viewport instead of center
- add vertical padding and scrolling support so the dialog is comfortable on smaller screens

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5e83edd448333a5bcec46f331ba9a