### PR TITLE
Adjust auth modal positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,6 +280,7 @@
         opacity: 0;
         transition: opacity 280ms ease;
         overflow-y: auto;
+        padding-top: 0;
       }
 
       .auth-modal[hidden] {


### PR DESCRIPTION
## Summary
- remove the top padding from the authentication modal overlay so the dialog sits at the very top of the viewport when opened

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d624b736648333a0fd12764b83d69c