### PR TITLE
Adjust modal close button vertical position

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
 
       .auth-modal__close {
         position: absolute;
-        top: 0.85rem;
+        top: calc(0.85rem + 100px);
         right: 0.85rem;
         display: inline-flex;
         align-items: center;


### PR DESCRIPTION
## Summary
- lower the auth modal close button by 100px to align it farther from the top edge

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d632db069c83339587494b32972794