### PR TITLE
Adjust auth modal close button position

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@
       .auth-modal__close {
         position: absolute;
         top: calc(0.85rem + 100px);
-        right: 0.85rem;
+        right: calc(0.85rem + 100px);
         display: inline-flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
## Summary
- shift the authentication modal close button 100px further from the right edge to align with the request

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d635dab2a0833388454cf5dec2eb51