### PR TITLE
Adjust auth modal layout to prevent scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,18 +270,16 @@
         position: fixed;
         inset: 0;
         display: flex;
-        align-items: stretch;
+        align-items: center;
         justify-content: center;
-        padding: clamp(2rem, 6vh, 4rem) clamp(1.5rem, 3vw, 3rem)
-          clamp(1.5rem, 3vw, 3rem);
+        padding: clamp(2rem, 6vh, 4rem) clamp(1.5rem, 3vw, 3rem);
         background: transparent;
         z-index: 40;
         pointer-events: none;
         opacity: 0;
         transition: opacity 280ms ease;
-        overflow-y: auto;
-        min-height: 100vh;
-        padding-top: 0;
+        overflow: hidden;
+        height: 100vh;
       }
 
       .auth-modal[hidden] {


### PR DESCRIPTION
## Summary
- center the authentication modal container and remove extra vertical overflow
- ensure the modal fills the viewport height while hiding unnecessary scrollbars

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d63aa68fd88333969bbd25ac181ca2