### PR TITLE
Hide scrollbar in authentication modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,7 @@
 
       .auth-modal__content {
         position: relative;
-        overflow-y: auto;
+        overflow: hidden;
         max-height: inherit;
         padding: clamp(1.75rem, 3vw, 2.5rem);
         display: flex;


### PR DESCRIPTION
## Summary
- prevent the authentication modal content container from rendering its own scrollbar by disabling overflow

## Testing
- no automated tests were run (static asset change)


------
https://chatgpt.com/codex/tasks/task_e_68d640d63a948333a260b4126846d26b