### PR TITLE
Reduce vertical padding in authentication modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,8 @@
         position: relative;
         overflow: hidden;
         max-height: inherit;
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        padding: clamp(0.1rem, 0.7vw, 0.4rem) clamp(1.6rem, 2.8vw, 2.25rem)
+          clamp(1.6rem, 2.8vw, 2.25rem);
         display: flex;
         justify-content: center;
         flex: 1;
@@ -374,7 +375,7 @@
         background: transparent;
         border: none;
         box-shadow: none;
-        padding: 0;
+        padding: 0 0 clamp(0.9rem, 1.8vw, 1.4rem);
         width: min(100%, 720px);
         max-width: 720px;
         position: relative;
@@ -392,7 +393,7 @@
 
       .auth-card--monitor .auth-card__monitor-content {
         position: absolute;
-        top: 12.5%;
+        top: 6%;
         left: 12%;
         right: 12%;
         bottom: 16%;


### PR DESCRIPTION
## Summary
- reduce the authentication modal's internal padding so the login/register popup sits closer to the top edge
- move the monitor screen content higher within the frame to eliminate the extra gap above the form

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68d64df490c4833395cfc0d8778fb59c