### PR TITLE
Remove top padding from auth modal content

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,6 +354,7 @@
         max-height: inherit;
         padding: clamp(0.1rem, 0.7vw, 0.4rem) clamp(1.6rem, 2.8vw, 2.25rem)
           clamp(1.6rem, 2.8vw, 2.25rem);
+        padding-top: 0;
         display: flex;
         justify-content: center;
         flex: 1;


### PR DESCRIPTION
## Summary
- remove the top padding from the auth modal content container so the login/register popup sits flush with the top edge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d65a3331fc833394d0ad68908ce1c9