### PR TITLE
Remove translucent backgrounds from login/register modal cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,11 +361,11 @@
       }
 
       .auth-card {
-        background: rgba(2, 6, 23, 0.82);
+        background: none;
         border-radius: 1.35rem;
-        border: 1px solid rgba(148, 163, 184, 0.18);
-        box-shadow: 0 28px 60px -18px rgba(15, 23, 42, 0.8);
-        backdrop-filter: blur(16px);
+        border: none;
+        box-shadow: none;
+        backdrop-filter: none;
         padding: clamp(1.85rem, 3vw, 2.75rem);
         color: rgba(248, 250, 252, 0.98);
         width: min(100%, 480px);
@@ -403,15 +403,9 @@
         justify-content: center;
         padding: clamp(1.85rem, 3vw, 2.75rem);
         border-radius: 1.35rem;
-        border: 1px solid rgba(59, 130, 246, 0.28);
-        background: linear-gradient(
-            145deg,
-            rgba(15, 23, 42, 0.92) 0%,
-            rgba(2, 6, 23, 0.86) 60%,
-            rgba(2, 6, 23, 0.94) 100%
-          );
-        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12),
-          0 22px 40px rgba(2, 6, 23, 0.55);
+        border: none;
+        background: none;
+        box-shadow: none;
       }
 
       .auth-card--monitor .auth-card__header,
@@ -432,38 +426,9 @@
         filter: drop-shadow(0 6px 14px rgba(30, 64, 175, 0.35));
       }
 
-      .auth-card--monitor::before {
-        content: "";
-        position: absolute;
-        inset: 9% 10% 13% 10%;
-        border-radius: 1.5rem;
-        background: radial-gradient(
-          circle at 50% 50%,
-          rgba(14, 165, 233, 0.28) 0%,
-          rgba(14, 116, 144, 0.12) 35%,
-          rgba(2, 6, 23, 0) 75%
-        );
-        opacity: 0.6;
-        filter: blur(0.5px);
-        z-index: 0;
-        pointer-events: none;
-      }
-
+      .auth-card--monitor::before,
       .auth-card--monitor::after {
-        content: "";
-        position: absolute;
-        inset: 8% 9% 12% 9%;
-        border-radius: 1.65rem;
-        border: 1px solid rgba(148, 163, 184, 0.08);
-        background: linear-gradient(
-          180deg,
-          rgba(255, 255, 255, 0.05) 0%,
-          rgba(59, 130, 246, 0.08) 45%,
-          rgba(15, 23, 42, 0.24) 100%
-        );
-        opacity: 0.45;
-        z-index: 0;
-        pointer-events: none;
+        content: none;
       }
 
       .auth-card--monitor > * {


### PR DESCRIPTION
## Summary
- remove the translucent background styling from the shared auth card so the popup no longer renders a frosted box
- drop the monitor-specific gradients and pseudo elements so the login form sits directly on the monitor artwork

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d661cb592483339be8d6f527104e5a