### PR TITLE
Expand monitor 2 modal height

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
 
       .auth-modal__dialog {
         position: relative;
-        width: min(100%, 820px);
+        width: min(100%, 1205px);
         max-height: none;
         height: 100%;
         transform: translateY(24px);
@@ -354,6 +354,7 @@
         padding: clamp(0.1rem, 0.7vw, 0.4rem) clamp(1.6rem, 2.8vw, 2.25rem)
           clamp(1.6rem, 2.8vw, 2.25rem);
         padding-top: 0;
+        padding-inline: 0;
         display: flex;
         justify-content: center;
         flex: 1;
@@ -376,8 +377,8 @@
         border: none;
         box-shadow: none;
         padding: 0 0 clamp(0.9rem, 1.8vw, 1.4rem);
-        width: min(100%, 820px);
-        max-width: 820px;
+        width: min(100%, 1205px);
+        max-width: 1205px;
         position: relative;
         color: rgba(248, 250, 252, 0.98);
         --monitor-screen-top: 6%;


### PR DESCRIPTION
## Summary
- increase the authentication modal dimensions so the second monitor frame is 300px taller
- remove inner padding that restricted the monitor frame from using the expanded width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6abe55b6483338f03fe6119bf8dab