### PR TITLE
Add animated matrix backdrop to authentication modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,48 @@
           rgba(2, 6, 23, 0.75);
         backdrop-filter: blur(8px);
         opacity: 0.92;
+        z-index: 0;
+      }
+
+      .auth-modal__matrix {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+        pointer-events: none;
+        opacity: 0;
+        transition: opacity 320ms ease;
+        z-index: 1;
+      }
+
+      .auth-modal.is-open .auth-modal__matrix {
+        opacity: 0.9;
+      }
+
+      .auth-modal__matrix::before {
+        content: "";
+        position: absolute;
+        inset: -45% -35% -45% -35%;
+        background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%27160%27%20height%3D%27320%27%3E%0A%20%20%3Crect%20width%3D%27160%27%20height%3D%27320%27%20fill%3D%27none%27%2F%3E%0A%20%20%3Cg%20fill%3D%27%2316f89d%27%20font-family%3D%27monospace%27%20font-size%3D%2718%27%20opacity%3D%270.45%27%3E%0A%20%20%20%20%3Ctext%20x%3D%274%27%20y%3D%2720%27%3E1010010110010110%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2720%27%20y%3D%2752%27%3E0010110100100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%278%27%20y%3D%2792%27%3E1101001011010010%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2730%27%20y%3D%27132%27%3E0101100101100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%27-6%27%20y%3D%27172%27%3E1010010110100101%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2716%27%20y%3D%27212%27%3E0101101001011010%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%272%27%20y%3D%27252%27%3E1001011010010110%3C%2Ftext%3E%0A%20%20%20%20%3Ctext%20x%3D%2726%27%20y%3D%27292%27%3E0010110100101101%3C%2Ftext%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E");
+        background-repeat: repeat;
+        background-size: 200px 360px;
+        background-position: 0 0;
+        animation: auth-modal-matrix-scroll 18s linear infinite;
+        opacity: 0.85;
+        mix-blend-mode: screen;
+      }
+
+      .auth-modal__matrix::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(
+            circle at 50% 20%,
+            rgba(59, 130, 246, 0.18) 0%,
+            rgba(2, 6, 23, 0.65) 55%,
+            rgba(1, 12, 20, 0.85) 100%
+          ),
+          linear-gradient(180deg, rgba(2, 6, 23, 0.65), rgba(2, 6, 23, 0.95));
+        opacity: 0.85;
       }
 
       .auth-modal__dialog {
@@ -315,6 +357,7 @@
         opacity: 0;
         display: flex;
         flex-direction: column;
+        z-index: 2;
       }
 
       .auth-modal.is-open .auth-modal__dialog {
@@ -861,6 +904,12 @@
         }
       }
 
+      @keyframes auth-modal-matrix-scroll {
+        to {
+          background-position: 0 360px;
+        }
+      }
+
       .monitor-decoration {
         display: block;
         width: 100%;
@@ -1070,6 +1119,7 @@
     </div>
     <div class="auth-modal" hidden aria-hidden="true">
       <div class="auth-modal__backdrop" data-auth-modal-close></div>
+      <div class="auth-modal__matrix" aria-hidden="true"></div>
       <div class="auth-modal__dialog" role="dialog" aria-modal="true" aria-label="Authentication panel">
         <div class="auth-modal__content" role="document"></div>
       </div>


### PR DESCRIPTION
## Summary
- add a dedicated matrix overlay layer to the authentication modal with animated binary rain
- ensure the modal dialog stacks above the new background and fades it in when opened

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6cd2abdc4833389a55d7aa9ad15cb