### PR TITLE
Align register modal spacing with login view

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,6 +455,10 @@
         box-shadow: none;
       }
 
+      .auth-card[data-auth-view="register"] .auth-card__monitor-content {
+        justify-content: flex-start;
+      }
+
       .auth-card--monitor .auth-card__header,
       .auth-card--monitor .auth-card__form,
       .auth-card--monitor .auth-card__footer {


### PR DESCRIPTION
## Summary
- align the register modal's monitor content to start so the fields sit at the same top offset as the login view

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d6d695c6f08333b502170345206edd