### PR TITLE
Adjust register modal position

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,6 +457,8 @@
 
       .auth-card[data-auth-view="register"] .auth-card__monitor-content {
         justify-content: flex-start;
+        top: calc(var(--monitor-screen-top, 6%) + 75px);
+        bottom: calc(var(--monitor-screen-bottom, 16%) - 75px);
       }
 
       .auth-card--monitor .auth-card__header,


### PR DESCRIPTION
## Summary
- lower the register modal content area by 75px so the form sits deeper inside the monitor frame

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7579f93448333a450fb306f939e16