### PR TITLE
Align register button styling with login

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,10 +624,6 @@
         transition: transform 150ms ease, box-shadow 150ms ease;
       }
 
-      .auth-card[data-auth-view="register"] .auth-card__submit {
-        background: linear-gradient(135deg, #6366f1, #ec4899);
-      }
-
       .auth-card__submit:hover {
         transform: translateY(-1px);
         box-shadow: 0 18px 35px -15px rgba(99, 102, 241, 0.65);
@@ -636,14 +632,6 @@
       .auth-card__submit:focus-visible {
         outline: none;
         box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.35);
-      }
-
-      .auth-card[data-auth-view="register"] .auth-card__submit:hover {
-        box-shadow: 0 18px 35px -15px rgba(236, 72, 153, 0.6);
-      }
-
-      .auth-card[data-auth-view="register"] .auth-card__submit:focus-visible {
-        box-shadow: 0 0 0 4px rgba(216, 180, 254, 0.3);
       }
 
       .auth-card__footer {


### PR DESCRIPTION
## Summary
- remove register-specific gradient and focus styles so the create account button uses the same blue treatment as login

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d77ab61bcc8333957542174da8be4e