### PR TITLE
Add Google sign-in image to login modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,6 +479,19 @@
         margin-top: clamp(1.75rem, 3vw, 2.25rem);
       }
 
+      .auth-card__social-login {
+        margin-top: clamp(1.5rem, 2.8vw, 2.1rem);
+        display: flex;
+        justify-content: center;
+      }
+
+      .auth-card__social-login img {
+        max-width: min(220px, 60%);
+        width: 100%;
+        height: auto;
+        filter: drop-shadow(0 12px 24px rgba(15, 23, 42, 0.45));
+      }
+
       .auth-card__hint {
         margin-top: clamp(0.75rem, 1.4vw, 1.1rem);
         font-size: 0.95rem;
@@ -1200,6 +1213,16 @@
           <div class="auth-card__footer">
             New here?
             <a class="auth-card__link" href="/pages/register.html" data-auth-switch="register">Create an account</a>
+          </div>
+          <div class="auth-card__social-login">
+            <img
+              src="images/index/google.png"
+              alt="Continue with Google"
+              width="256"
+              height="83"
+              loading="lazy"
+              decoding="async"
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add styling hook for social login artwork in the authentication modal
- display the newly provided Google sign-in graphic beneath the login form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c3de74708333bd1d2b13066fa5f3