### PR TITLE
Add hello note after login action button

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,14 @@
         transition: opacity 260ms ease;
       }
 
+      .auth-actions__note {
+        display: block;
+        font-size: 0.85rem;
+        color: rgba(226, 232, 240, 0.75);
+        text-align: center;
+        letter-spacing: 0.06em;
+      }
+
       .auth-actions__content.is-screen-saver-active .auth-actions__buttons {
         opacity: 0;
         visibility: hidden;
@@ -1113,6 +1121,7 @@
           </div>
           <div class="auth-actions__buttons" role="group" aria-label="Authentication actions">
             <a class="auth-actions__button" href="pages/login.html">Log in</a>
+            <span class="auth-actions__note">hello: text</span>
             <a class="auth-actions__button" href="pages/register.html">Register</a>
             <button class="auth-actions__button auth-actions__button--ghost" type="button">
               Continue as guest


### PR DESCRIPTION
## Summary
- add a small "hello: text" note immediately after the login action button
- style the note to match the existing authentication action layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7c79f52dc83339b1c08b9a6cbad72