### PR TITLE
Add greeting text after login button

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,13 @@
         transition: opacity 260ms ease;
       }
 
+      .auth-actions__hello {
+        text-align: center;
+        color: rgba(226, 232, 240, 0.92);
+        font-size: 0.95rem;
+        letter-spacing: 0.08em;
+      }
+
       .auth-actions__content.is-screen-saver-active .auth-actions__buttons {
         opacity: 0;
         visibility: hidden;
@@ -1113,6 +1120,7 @@
           </div>
           <div class="auth-actions__buttons" role="group" aria-label="Authentication actions">
             <a class="auth-actions__button" href="pages/login.html">Log in</a>
+            <span class="auth-actions__hello">hello</span>
             <a class="auth-actions__button" href="pages/register.html">Register</a>
             <button class="auth-actions__button auth-actions__button--ghost" type="button">
               Continue as guest


### PR DESCRIPTION
## Summary
- add a "hello" label after the login action on the landing page
- style the greeting text to match the existing authentication monitor theme

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7d3d1be808333922196a4ec4f19de