### PR TITLE
Delay scene animation until assets load

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -593,29 +593,41 @@ const setCrosshairInteractableState = (canInteract) => {
   previousCrosshairInteractableState = nextCrosshairInteractableState;
 };
 
-const bootstrapScene = () => {
+const bootstrapScene = async () => {
   if (!(canvas instanceof HTMLCanvasElement)) {
     return;
   }
 
-  sceneController = initScene(canvas, {
-    onControlsLocked() {
-      instructions?.setAttribute("hidden", "");
-    },
-    onControlsUnlocked() {
-      instructions?.removeAttribute("hidden");
-      setCrosshairInteractableState(false);
-      hideTerminalToast();
-    },
-    onTerminalOptionSelected(option) {
-      playTerminalInteractionSound();
-      openQuickAccessModal(option);
-      showTerminalToast(option);
-    },
-    onTerminalInteractableChange: setCrosshairInteractableState,
-  });
+  try {
+    const controller = await initScene(canvas, {
+      onControlsLocked() {
+        instructions?.setAttribute("hidden", "");
+      },
+      onControlsUnlocked() {
+        instructions?.removeAttribute("hidden");
+        setCrosshairInteractableState(false);
+        hideTerminalToast();
+      },
+      onTerminalOptionSelected(option) {
+        playTerminalInteractionSound();
+        openQuickAccessModal(option);
+        showTerminalToast(option);
+      },
+      onTerminalInteractableChange: setCrosshairInteractableState,
+    });
 
-  sceneController?.setPlayerHeight?.(DEFAULT_PLAYER_HEIGHT, { persist: true });
+    sceneController = controller;
+    sceneController?.setPlayerHeight?.(DEFAULT_PLAYER_HEIGHT, { persist: true });
+    setErrorMessage("");
+  } catch (error) {
+    console.error("Failed to initialize the hangar scene", error);
+    sceneController = null;
+    setCrosshairInteractableState(false);
+    instructions?.removeAttribute("hidden");
+    setErrorMessage(
+      "We couldn't start the hangar simulation. Please refresh and try again."
+    );
+  }
 
 };
 


### PR DESCRIPTION
## Summary
- convert `initScene` to an async initializer that waits for texture loads before starting animation and returning the controller
- update `loadClampedTexture` to surface promises so initialization can await asset loading and clean up on failure
- make `bootstrapScene` async, awaiting scene setup before wiring player state and surfacing an error when initialization fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbd5be46188333a3518cad818d6603