### PR TITLE
Rename inspector tab to edit selection controls

### DIFF
--- a/model_editor.html
+++ b/model_editor.html
@@ -446,10 +446,10 @@
         type="button"
         class="left-menu__link"
         role="tab"
-        data-panel-target="inspector"
-        aria-controls="inspector"
+        data-panel-target="edit-controls"
+        aria-controls="edit-controls"
       >
-        Inspector
+        Edit
       </button>
       <button
         type="button"
@@ -528,13 +528,13 @@
 
       <section
         class="sidebar__section"
-        id="inspector"
-        aria-labelledby="inspector-heading"
+        id="edit-controls"
+        aria-labelledby="edit-heading"
         role="tabpanel"
         aria-live="polite"
         data-panel
       >
-        <h2 id="inspector-heading">Inspector</h2>
+        <h2 id="edit-heading">Edit Selection</h2>
         <div class="control-group">
           <label for="figureId">Figure ID</label>
           <input


### PR DESCRIPTION
## Summary
- rename the sidebar tab from "Inspector" to "Edit" so the menu reflects its editing purpose
- update the associated panel heading and identifiers to match the new label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcc3d07c60833387c0648a11e7a689