### PR TITLE
Allow figures to move below the floor

### DIFF
--- a/scripts/model-editor.js
+++ b/scripts/model-editor.js
@@ -3728,14 +3728,6 @@ function handleCenterInputChange(axis, input) {
     return;
   }
 
-  if (axis === "y") {
-    const clampedValue = Math.max(value, 0);
-    if (clampedValue !== value) {
-      value = clampedValue;
-      input.value = clampedValue.toFixed(2);
-    }
-  }
-
   const box = reusableBoundingBox.setFromObject(currentSelection);
   const actualCenter = box.getCenter(reusableCenterVector);
   const displayCenter = getDisplayCenterFromBox(box, reusableDisplayCenterVector);


### PR DESCRIPTION
## Summary
- allow the inspector center controls to accept negative Y values so figures can be moved below the ground plane

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904c9e468548333994edaf3d4d78824