### PR TITLE
Add quick access market with persistent trades

### DIFF
--- a/game.html
+++ b/game.html
@@ -1615,6 +1615,17 @@
         box-shadow: none;
       }
 
+      .quick-access-modal__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        margin-top: 0.75rem;
+      }
+
+      .quick-access-modal__actions .quick-access-modal__action {
+        margin-top: 0;
+      }
+
       .mission-requirement {
         margin: 0.15rem 0 0.35rem;
         color: rgba(226, 232, 240, 0.85);
@@ -3342,33 +3353,23 @@
       </header>
       <section class="quick-access-modal__section">
         <h3 class="quick-access-modal__section-title">Contracts</h3>
-        <div class="quick-access-modal__card-grid">
-          <article class="quick-access-modal__card">
-            <p class="quick-access-modal__status-tag">Buy</p>
-            <h3>Ionized ore</h3>
-            <p>Vendors paying a premium for clean ore—bonus for &lt; 2% contamination.</p>
-          </article>
-          <article class="quick-access-modal__card">
-            <p class="quick-access-modal__status-tag" data-status="critical">Sell</p>
-            <h3>Shield capacitors</h3>
-            <p>Fleet retrofit underway. Immediate delivery to hangar bay loading cranes.</p>
-          </article>
-          <article class="quick-access-modal__card">
-            <p class="quick-access-modal__status-tag">Trade</p>
-            <h3>Drone optics</h3>
-            <p>Swap surplus fiber arrays for calibrated survey lenses—limited lots remain.</p>
-          </article>
-        </div>
+        <p class="quick-access-modal__subtitle" data-market-balance>
+          Balance: syncing...
+        </p>
+        <div class="quick-access-modal__card-grid" data-market-grid></div>
+        <p class="quick-access-modal__list-item" data-market-empty hidden>
+          Market feed unavailable. Storage access may be limited.
+        </p>
       </section>
       <hr class="quick-access-modal__divider" />
       <section class="quick-access-modal__section">
         <h3 class="quick-access-modal__section-title">Exchange cues</h3>
         <ul class="quick-access-modal__list">
           <li class="quick-access-modal__list-item">
-            Prices spike after dusk cycle; queue early if you need shielding or batteries.
+            Prices react to each trade; expect surcharges on hot items and relief on selloffs.
           </li>
           <li class="quick-access-modal__list-item">
-            Verified squads can reserve cargo pods remotely—submit your manifest here.
+            Listings persist between shifts. Use quick access to adjust loads before deploying.
           </li>
         </ul>
       </section>

--- a/scripts/market-state-storage.js
+++ b/scripts/market-state-storage.js
@@ -1,0 +1,156 @@
+const MARKET_STORAGE_KEY = "dustyNova.market";
+
+const DEFAULT_MARKET_ITEMS = [
+  {
+    id: "water-ice",
+    name: "Water Ice Contracts",
+    price: 125,
+    stock: 18,
+    accent: "💧",
+    summary: "Hydration caches from polar harvesters.",
+  },
+  {
+    id: "ferrocrete",
+    name: "Ferrocrete Mix",
+    price: 210,
+    stock: 10,
+    accent: "🧱",
+    summary: "Prefabricated regolith binder for builds.",
+  },
+  {
+    id: "reactor-cells",
+    name: "Micro Reactor Cells",
+    price: 460,
+    stock: 6,
+    accent: "⚡",
+    summary: "Sealed units for remote drone beacons.",
+  },
+  {
+    id: "survey-data",
+    name: "Survey Data Packets",
+    price: 95,
+    stock: 24,
+    accent: "📡",
+    summary: "Encrypted scans of nearby mineral veins.",
+  },
+];
+
+const getMarketStorage = (() => {
+  let resolved = false;
+  let storage = null;
+
+  return () => {
+    if (resolved) {
+      return storage;
+    }
+
+    resolved = true;
+
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    try {
+      storage = window.localStorage;
+      const probeKey = `${MARKET_STORAGE_KEY}.probe`;
+      storage.setItem(probeKey, "1");
+      storage.removeItem(probeKey);
+    } catch (error) {
+      console.warn("Unable to access market storage", error);
+      storage = null;
+    }
+
+    return storage;
+  };
+})();
+
+const normalizeMarketItem = (item, fallback) => {
+  const normalized = { ...(fallback ?? {}) };
+  const id = typeof item?.id === "string" ? item.id.trim() : "";
+
+  if (!id) {
+    return fallback ?? null;
+  }
+
+  normalized.id = id;
+  normalized.name = typeof item?.name === "string" && item.name.trim() !== ""
+    ? item.name.trim()
+    : fallback?.name ?? id;
+  normalized.accent = typeof item?.accent === "string" && item.accent.trim() !== ""
+    ? item.accent.trim()
+    : fallback?.accent ?? "";
+  normalized.summary = typeof item?.summary === "string" && item.summary.trim() !== ""
+    ? item.summary.trim()
+    : fallback?.summary ?? "";
+
+  const price = Number.isFinite(item?.price) ? Math.max(1, Math.round(item.price)) : null;
+  normalized.price = price ?? fallback?.price ?? 1;
+
+  const stock = Number.isFinite(item?.stock) ? Math.max(0, Math.round(item.stock)) : null;
+  normalized.stock = stock ?? fallback?.stock ?? 0;
+
+  return normalized;
+};
+
+const getDefaultMarketState = () => ({
+  items: DEFAULT_MARKET_ITEMS.map((item) => normalizeMarketItem(item, item)),
+});
+
+const sanitizeMarketState = (state) => {
+  const defaultState = getDefaultMarketState();
+  if (!state || !Array.isArray(state.items)) {
+    return defaultState;
+  }
+
+  const normalizedItems = state.items
+    .map((item, index) => normalizeMarketItem(item, defaultState.items[index]))
+    .filter(Boolean);
+
+  if (normalizedItems.length === 0) {
+    return defaultState;
+  }
+
+  return { items: normalizedItems };
+};
+
+export const loadMarketState = () => {
+  const storage = getMarketStorage();
+
+  if (!storage) {
+    return getDefaultMarketState();
+  }
+
+  try {
+    const storedValue = storage.getItem(MARKET_STORAGE_KEY);
+    if (!storedValue) {
+      return getDefaultMarketState();
+    }
+
+    const parsed = JSON.parse(storedValue);
+    return sanitizeMarketState(parsed);
+  } catch (error) {
+    console.warn("Unable to read stored market state", error);
+  }
+
+  return getDefaultMarketState();
+};
+
+export const persistMarketState = (state) => {
+  const storage = getMarketStorage();
+
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    const normalizedState = sanitizeMarketState(state);
+    storage.setItem(MARKET_STORAGE_KEY, JSON.stringify(normalizedState));
+    return true;
+  } catch (error) {
+    console.warn("Unable to persist market state", error);
+  }
+
+  return false;
+};
+
+export { getDefaultMarketState };


### PR DESCRIPTION
## Summary
- add a persisted market state model with default listings and storage helpers
- render actionable market cards in the quick access modal with balance-aware buy/sell flows and dynamic pricing
- update modal lifecycle and styling to initialize and tear down market interactions cleanly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f8491e99083339f82bf22a26c838a)