### PR TITLE
Prevent terrain paint camera resets

### DIFF
--- a/scripts/map-maker-3d.js
+++ b/scripts/map-maker-3d.js
@@ -481,7 +481,9 @@ export const initMapMaker3d = ({
   };
 
   const updateMap = (map) => {
-    applyMapGeometry(map, { resetCamera: true });
+    const shouldResetCamera =
+      !lastMap || map.width !== mapWidth || map.height !== mapHeight;
+    applyMapGeometry(map, { resetCamera: shouldResetCamera });
   };
 
   const updateTerrainTypeDisplay = (nextValue) => {


### PR DESCRIPTION
### Motivation
- Painting or updating terrain should not unexpectedly reorient the 3D view, so the camera must only be reset when the map layout actually changes.

### Description
- Change `updateMap` to compute `shouldResetCamera` and only request a camera reset when there was no previous map or when `map.width` or `map.height` differ from the last known values.
- Pass `{ resetCamera: shouldResetCamera }` into `applyMapGeometry` instead of always forcing `resetCamera: true`.
- The change uses the existing `lastMap`, `mapWidth`, and `mapHeight` state to decide whether to reset the camera.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69690ff415748333b4fb26ee446f227c)