### PR TITLE
Show terrain info only when 'Show tile' is active

### DIFF
--- a/scripts/map-maker.js
+++ b/scripts/map-maker.js
@@ -231,6 +231,7 @@ function setTextureVisibility(isEnabled) {
   if (elements.mapGrid) {
     elements.mapGrid.dataset.showTextures = String(isEnabled);
   }
+  setTerrainInfoVisibility(isEnabled);
   syncTextureToggleLabel(isEnabled);
 }
 
@@ -1060,7 +1061,7 @@ function initControls() {
   }
   setTextureVisibility(defaultTextureState);
   syncTerrainMenuButtons();
-  setTerrainInfoVisibility(state.showTerrainInfo);
+  setTerrainInfoVisibility(getTextureVisibility());
   if (elements.textureToggle) {
     elements.textureToggle.addEventListener("change", (event) => {
       setTerrainMenu(event.target.checked ? "textures" : null);
@@ -1074,7 +1075,7 @@ function initControls() {
 
   if (elements.terrainInfoToggle) {
     elements.terrainInfoToggle.addEventListener("click", () => {
-      setTerrainInfoVisibility(!state.showTerrainInfo);
+      setTerrainMenu(getTextureVisibility() ? null : "textures");
     });
   }
 


### PR DESCRIPTION
### Motivation
- The terrain info buttons in the map maker sidebar should only be visible when tile textures are shown so the UI is less noisy and the info is relevant to the current view.

### Description
- Call `setTerrainInfoVisibility(isEnabled)` from `setTextureVisibility` to sync the info grid with texture visibility.
- Initialize the info visibility with `setTerrainInfoVisibility(getTextureVisibility())` in `initControls` so the grid follows the initial texture state.
- Change the `terrainInfoToggle` click handler to call `setTerrainMenu(getTextureVisibility() ? null : "textures")` so the toggle routes through the same menu/texture state logic.
- All changes are in `scripts/map-maker.js` and ensure the terrain info buttons only appear when textures/tiles are enabled.

### Testing
- Ran a Playwright script that served `map_maker.html`, opened the terrain tab, clicked the `Show tile` control, and captured a screenshot; the script completed and produced `artifacts/map-maker-terrain.png` successfully.
- No unit tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a076809208333babd789212794988)