### PR TITLE
Update last update timestamp on local save

### DIFF
--- a/scripts/map-maker.js
+++ b/scripts/map-maker.js
@@ -458,6 +458,7 @@ function saveMapToLocalStorage() {
     return false;
   }
 
+  updateLastUpdatedDisplay();
   setTemporaryButtonLabel(elements.saveLocalButton, "Saved", "save");
   updateLocalSaveButtonsState();
   return true;


### PR DESCRIPTION
### Motivation
- Ensure the map maker UI reflects recent changes by refreshing the "Last update" display after a successful local save.

### Description
- Added a call to `updateLastUpdatedDisplay()` in `saveMapToLocalStorage()` so the `Last update` timestamp is refreshed when a map is saved to local storage in `scripts/map-maker.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a09bdd8e483338b480cf795633c98)