### PR TITLE
Track map maker last update timestamp

### DIFF
--- a/scripts/outside-map.js
+++ b/scripts/outside-map.js
@@ -245,6 +245,7 @@ const DEFAULT_OUTSIDE_MAP_TEMPLATE = {
   name: "outside-yard",
   region: "perimeter",
   notes: "",
+  lastUpdatedAt: null,
   width: 16,
   height: 12,
   cells: Array.from({ length: 16 * 12 }, () => "nonmetal"),
@@ -278,11 +279,25 @@ export function normalizeOutsideMap(definition) {
   const height = clampOutsideMapDimension(definition.height);
   const totalCells = width * height;
   const sourceCells = Array.isArray(definition.cells) ? definition.cells : [];
+  const lastUpdatedAtValue = definition.lastUpdatedAt;
+  let lastUpdatedAt = null;
+  if (typeof lastUpdatedAtValue === "string" && lastUpdatedAtValue.trim()) {
+    lastUpdatedAt = lastUpdatedAtValue;
+  } else if (
+    typeof lastUpdatedAtValue === "number" &&
+    Number.isFinite(lastUpdatedAtValue)
+  ) {
+    const parsedDate = new Date(lastUpdatedAtValue);
+    if (!Number.isNaN(parsedDate.getTime())) {
+      lastUpdatedAt = parsedDate.toISOString();
+    }
+  }
 
   const normalized = {
     name: typeof definition.name === "string" ? definition.name : "",
     region: typeof definition.region === "string" ? definition.region : "",
     notes: typeof definition.notes === "string" ? definition.notes : "",
+    lastUpdatedAt,
     width,
     height,
     cells: [],


### PR DESCRIPTION
### Motivation
- Provide visibility into when a map was last modified by storing and showing a "Last update" timestamp for maps created in the map maker.

### Description
- Persist `lastUpdatedAt` in the outside map data by adding it to the default template and normalizing it in `normalizeOutsideMap` to accept ISO strings or numeric timestamps in `scripts/outside-map.js`.
- Add parsing and display helpers (`parseLastUpdatedAt`, `syncLastUpdatedDisplay`, `bumpLastUpdated`) and wire the UI `#lastUpdateDisplay` to the map state in `scripts/map-maker.js`.
- Update `updateJsonPreview` to optionally bump the timestamp, and call it with `bumpLastUpdated: true` on user-driven edits (`paintCell`, `resizeMap`, `updateMapMetadata`, `resetMap`, `generateRandomMap`, etc.) while preserving stored timestamps when importing or loading.
- Minor adjustments ensure `state.map.lastUpdatedAt` is written as an ISO string when bumped so saves include the timestamp.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0b2a30908333958108c3a9e8662b)