### PR TITLE
Hide terrain brush size row unless Brush mode active

### DIFF
--- a/map_maker.html
+++ b/map_maker.html
@@ -811,7 +811,12 @@
               <select id="terrainTypeSelect"></select>
             </label>
           </div>
-          <div class="terrain-control-row terrain-brush-row" id="terrainBrushRow">
+          <div
+            class="terrain-control-row terrain-brush-row"
+            id="terrainBrushRow"
+            hidden
+            aria-hidden="true"
+          >
             <label class="terrain-control-label" for="terrainBrushSize">
               Brush size
             </label>

--- a/scripts/map-maker.js
+++ b/scripts/map-maker.js
@@ -187,7 +187,14 @@ function syncTerrainBrushVisibility() {
   if (!elements.terrainBrushRow) {
     return;
   }
-  const isVisible = state.terrainMode === "brush";
+  const brushButton = elements.terrainModeButtons.find(
+    (button) => button.dataset.terrainMode === "brush"
+  );
+  const isVisible = Boolean(
+    brushButton &&
+      (brushButton.getAttribute("aria-pressed") === "true" ||
+        brushButton.classList.contains("is-active"))
+  );
   elements.terrainBrushRow.hidden = !isVisible;
   elements.terrainBrushRow.setAttribute("aria-hidden", String(!isVisible));
 }


### PR DESCRIPTION
### Motivation
- The terrain brush size control should be hidden by default and only shown when the Brush mode is actively selected for clarity and accessibility.
- Previously the visibility was derived only from `state.terrainMode`, which could be out of sync with the actual button ARIA/active state.

### Description
- Add `hidden` and `aria-hidden="true"` to the `<div id="terrainBrushRow">` in `map_maker.html` so the brush size row starts hidden.
- Update `syncTerrainBrushVisibility()` in `scripts/map-maker.js` to derive visibility from the Brush mode button element by finding the button with `data-terrain-mode="brush"` and checking `getAttribute("aria-pressed") === "true"` or `classList.contains("is-active")` instead of relying solely on `state.terrainMode`.
- Preserve existing calls to `syncTerrainBrushVisibility()` (for example in `setTerrainMenu()` and initialization paths) so visibility is synchronized after mode toggles and on init.

### Testing
- Launched a local HTTP server and loaded `map_maker.html` with a headless Playwright script to capture a screenshot and verify the brush row is hidden by default, and the screenshot generation completed successfully.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a5bedc1e48333a6863fb10df62b72)