### PR TITLE
Change Digger quick slot icon to sci-fi glyph

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -947,7 +947,7 @@ const quickSlotDefinitions = [
     id: "digger",
     label: "Digger",
     description: "Standard issue excavation module.",
-    icon: "🪓",
+    icon: "🛸",
   },
   {
     id: DRONE_QUICK_SLOT_ID,


### PR DESCRIPTION
### Motivation
- Update the Digger quick slot icon to better match the game's sci‑fi visual language.

### Description
- Replace the `digger` quick slot `icon` emoji in `scripts/game.js` from "🪓" to "🛸".

### Testing
- Rendered `game.html` using `python -m http.server` and captured a screenshot with Playwright to `artifacts/digger-icon.png`; initial Playwright attempts timed out but the final run succeeded and produced the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3ab2d6b08333a5ad89fcc129b1f3)