### PR TITLE
Reduce terrain tile seams by insetting UVs

### DIFF
--- a/scripts/scene.js
+++ b/scripts/scene.js
@@ -4156,6 +4156,18 @@ export const initScene = (
           terrainPlaneSegments
         );
         geometry.rotateX(-Math.PI / 2);
+        const uvInset = 0.0025;
+        const uvs = geometry.attributes.uv;
+        for (let index = 0; index < uvs.count; index += 1) {
+          const u = uvs.getX(index);
+          const v = uvs.getY(index);
+          uvs.setXY(
+            index,
+            u * (1 - uvInset * 2) + uvInset,
+            v * (1 - uvInset * 2) + uvInset
+          );
+        }
+        uvs.needsUpdate = true;
         const positions = geometry.attributes.position;
         const centerX = mapLeftEdge + column * cellSize + cellSize / 2;
         const centerZ = mapNearEdge + row * cellSize + cellSize / 2;


### PR DESCRIPTION
### Motivation
- Visible borders (seams) appeared between outside terrain tiles due to texture sampling at tile edges, which the change aims to eliminate.

### Description
- Adjusted `createTerrainTileGeometry` in `scripts/scene.js` to inset UV coordinates slightly by `uvInset = 0.0025` to avoid sampling texture borders.
- The patch iterates `geometry.attributes.uv`, remaps each UV via `uvs.setXY(...)`, and marks `uvs.needsUpdate = true` so the updated UVs are used at runtime.
- No other geometry or material code was changed; change is localized to UV handling for terrain plane geometry.

### Testing
- Launched a local dev server with `python -m http.server` and ran a Playwright script to load `game.html` and capture a screenshot, which succeeded and produced `artifacts/terrain-no-borders.png`.
- The change was committed and the repository status shows the modified file `scripts/scene.js` as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b938e388c83339bcd68e45b79e01b)