### PR TITLE
Disable operations-exterior in lift modal

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -4541,7 +4541,10 @@ const renderLiftModalFloors = () => {
     return;
   }
 
-  const disabledLiftFloorIds = new Set(["operations-concourse"]);
+  const disabledLiftFloorIds = new Set([
+    "operations-concourse",
+    "operations-exterior",
+  ]);
 
   floors.forEach((floor) => {
     if (!floor) {


### PR DESCRIPTION
### Motivation
- Exclude the external surface floor (`operations-exterior`) from the lift selection modal so it does not appear as a selectable quick-access lift destination.

### Description
- Add `"operations-exterior"` to the `disabledLiftFloorIds` set in `scripts/game.js` so `renderLiftModalFloors` filters it out of the floor list.

### Testing
- Performed a visual smoke test by starting a local server (`python -m http.server 8000`) and capturing a headless browser screenshot of `http://127.0.0.1:8000/index.html` with Playwright; the screenshot `artifacts/lift-modal.png` was generated successfully.
- No automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d0cc195c8333809ae32ea63523b2)