### PR TITLE
Fix immediate terrain depletion updates on surface

### DIFF
--- a/scripts/scene.js
+++ b/scripts/scene.js
@@ -17103,8 +17103,11 @@ export const initScene = (
   };
 
   const findTerrainTileAtPosition = (position) => {
-    if (!position || !Number.isFinite(position.x) || !Number.isFinite(position.y) ||
-        !Number.isFinite(position.z)) {
+    if (
+      !position ||
+      !Number.isFinite(position.x) ||
+      !Number.isFinite(position.z)
+    ) {
       return null;
     }
 
@@ -17112,7 +17115,7 @@ export const initScene = (
       return null;
     }
 
-    const point = new THREE.Vector3(position.x, position.y, position.z);
+    const point = new THREE.Vector3(position.x, 0, position.z);
     const bounds = new THREE.Box3();
 
     for (const tile of activeTerrainTiles) {
@@ -17121,7 +17124,12 @@ export const initScene = (
       }
 
       bounds.setFromObject(tile);
-      if (bounds.containsPoint(point)) {
+      if (
+        point.x >= bounds.min.x &&
+        point.x <= bounds.max.x &&
+        point.z >= bounds.min.z &&
+        point.z <= bounds.max.z
+      ) {
         return tile;
       }
     }


### PR DESCRIPTION
### Motivation
- Surface terrain tiles did not update visually immediately after digging because the tile lookup required the player's Y coordinate to be inside the tile bounds, causing updates to wait for area reload/windowing refresh.

### Description
- Modified `findTerrainTileAtPosition` in `scripts/scene.js` to stop validating `position.y` and instead match tiles by their X/Z footprint.
- Created the sample point with `new THREE.Vector3(position.x, 0, position.z)` and replaced `bounds.containsPoint(point)` with explicit X/Z range checks against `bounds.min`/`bounds.max`.
- This ensures calls like `setTerrainDepletedAtPosition` update the tile material/colors immediately without forcing a terrain rebuild or area reload.

### Testing
- Ran `npm test --silent` and the test suite passed, with `tests/math.test.js` reporting 3 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce736f5fc8333ac747dbdbd6283ed)